### PR TITLE
[codex] Resume restored sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ codex-restore -a        # recreates and attaches to the session
 ```
 
 Use `-f` to force re-creation of existing-named windows.
+Each restored Codex window also sends `codex resume --last` after the pane is recreated.
+Wrapper restores send the equivalent command for their tool: `claude --continue` or `gemini --resume latest`.
 
 If tmux sessions are already running (no manifest needed):
 ```bash

--- a/bin/codex-restore
+++ b/bin/codex-restore
@@ -6,6 +6,29 @@ set -euo pipefail
 #  -a, --attach   Attach/switch to session after restore
 #  -f, --force    Recreate windows if names already exist
 
+script_name=$(basename "${0:-codex-restore}")
+tool_name="${CODEX_TOOL_NAME:-codex}"
+case "$script_name" in
+  claude-restore) tool_name="${CODEX_TOOL_NAME:-claude}" ;;
+  gemini-restore) tool_name="${CODEX_TOOL_NAME:-gemini}" ;;
+esac
+
+send_resume_command() {
+  local session="$1"
+  local window_name="$2"
+  case "$tool_name" in
+    codex)
+      tmux send-keys -t "$session:$window_name" codex resume --last C-m
+      ;;
+    claude)
+      tmux send-keys -t "$session:$window_name" claude --continue C-m
+      ;;
+    gemini)
+      tmux send-keys -t "$session:$window_name" gemini --resume latest C-m
+      ;;
+  esac
+}
+
 attach=0
 force=0
 args_pos=()
@@ -55,6 +78,7 @@ tmux has-session -t "$SESSION" 2>/dev/null || tmux new-session -d -s "$SESSION" 
   esac
   args=${args:-${CODEX_ARGS:-}}
   CODEX_NAME="$name" CODEX_CMD="$cmd" CODEX_ARGS="$args" codex-add -d "${dir:-$HOME}"
+  send_resume_command "$SESSION" "$name"
 done
 
 if [ "$attach" -eq 1 ]; then
@@ -66,4 +90,3 @@ if [ "$attach" -eq 1 ]; then
 fi
 
 echo "Restore complete from $MANIFEST_PATH"
-

--- a/docs/plans/2026-04-08-restore-session-resume-design.md
+++ b/docs/plans/2026-04-08-restore-session-resume-design.md
@@ -1,0 +1,22 @@
+# Restore Session Resume Design
+
+## Goal
+Ensure `codex-restore` recreates each saved window and immediately resumes the last CLI session inside that restored pane, with equivalent behavior for the Claude and Gemini wrappers.
+
+## Approach
+Keep the change scoped to `bin/codex-restore`. After each window is created through `codex-add`, send one tool-specific follow-up command into the new tmux pane so the CLI resumes its last conversation state. Tool selection continues to come from the wrapper mechanism via `CODEX_TOOL_NAME`, so `codex-restore`, `claude-restore`, and `gemini-restore` all share the same implementation.
+
+## Resume Commands
+- `codex`: `codex resume --last`
+- `claude`: `claude --continue`
+- `gemini`: `gemini --resume latest`
+
+## Window Handling
+- Apply the resume command only to windows that were created during the current restore run.
+- If a window already exists and restore skips it because `-f` was not used, do not inject any command into that existing pane.
+- If `-f` is used, recreate the window first, then inject the resume command into the replacement window.
+
+## Testing
+- Add restore-focused tests that stub tmux and assert `send-keys` is issued after `new-window`.
+- Cover all three tool modes by setting `CODEX_TOOL_NAME` in the test environment.
+- Run the targeted test file after implementation to confirm the new behavior without regressing existing add/resume coverage.

--- a/docs/plans/2026-04-08-restore-session-resume.md
+++ b/docs/plans/2026-04-08-restore-session-resume.md
@@ -1,0 +1,60 @@
+# Restore Session Resume Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make restore recreate each saved window and then run the correct tool-specific resume command inside that window for Codex, Claude, and Gemini.
+
+**Architecture:** Keep restore orchestration in `bin/codex-restore` and derive the resume command from the active tool name. Reuse the existing `codex-add` path to create windows, then target the newly created tmux window with `send-keys` so only restored panes receive the resume command.
+
+**Tech Stack:** Bash entrypoints, tmux CLI, Python `unittest`/`pytest`.
+
+---
+
+### Task 1: Add failing restore tests
+
+**Files:**
+- Modify: `tests/test_add_scripts.py`
+
+**Step 1: Write the failing test**
+
+Add tests that run `bin/codex-restore` against a stub tmux binary and assert:
+- restored Codex windows receive `send-keys -t <session>:<window> codex resume --last C-m`
+- restored Claude windows receive `send-keys -t <session>:<window> claude --continue C-m`
+- restored Gemini windows receive `send-keys -t <session>:<window> gemini --resume latest C-m`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest -q tests/test_add_scripts.py -k restore`
+Expected: FAIL because `bin/codex-restore` currently recreates windows but does not send any resume command.
+
+### Task 2: Implement restore-time resume injection
+
+**Files:**
+- Modify: `bin/codex-restore`
+
+**Step 1: Write minimal implementation**
+
+Update restore to:
+- resolve the active tool from `CODEX_TOOL_NAME`
+- map that tool to its resume command
+- capture the tmux window index returned by `codex-add`
+- send the mapped command into the new window with `tmux send-keys`
+
+**Step 2: Run test to verify it passes**
+
+Run: `python3 -m pytest -q tests/test_add_scripts.py -k restore`
+Expected: PASS with the new `send-keys` calls recorded for each tool mode.
+
+### Task 3: Verify surrounding behavior and docs
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update the user-facing restore description**
+
+Document that restored Codex, Claude, and Gemini windows automatically issue their respective resume command after the pane is recreated.
+
+**Step 2: Run the targeted regression suite**
+
+Run: `python3 -m pytest -q tests/test_add_scripts.py tests/test_claude_wrappers.py`
+Expected: PASS with restore coverage added and wrapper behavior unchanged.

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -195,6 +195,103 @@ exit 0
         )
 
 
+class RestoreScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="restore-script-test-"))
+        self.tmux_log = self.tmpdir / "tmux.log"
+        self.codex_add_log = self.tmpdir / "codex-add.log"
+        self.manifest = self.tmpdir / "manifest.tsv"
+
+        tmux_stub = """#!/usr/bin/env bash
+set -euo pipefail
+log="${TMUX_LOG}"
+echo "$*" >> "$log"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  list-windows)
+    if [ -n "${TMUX_WINDOWS_OUTPUT:-}" ]; then
+      printf '%s\n' "${TMUX_WINDOWS_OUTPUT}"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+"""
+        codex_add_stub = """#!/usr/bin/env bash
+set -euo pipefail
+echo "$CODEX_NAME|$CODEX_CMD|$CODEX_ARGS|$*" >> "${CODEX_ADD_LOG}"
+exit 0
+"""
+        make_executable(self.tmpdir / "tmux", tmux_stub)
+        make_executable(self.tmpdir / "codex-add", codex_add_stub)
+
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\nproj\t/tmp/project\tcodex\t\n",
+            encoding="utf-8",
+        )
+
+        self.env = os.environ.copy()
+        self.env["PATH"] = f"{self.tmpdir}:{self.env.get('PATH', '')}"
+        self.env["TMUX_LOG"] = str(self.tmux_log)
+        self.env["CODEX_ADD_LOG"] = str(self.codex_add_log)
+        self.env["CODEX_AUTOSERVICE_CHOICE"] = "no"
+        self.env.pop("TMUX", None)
+        self.env["HOME"] = str(self.tmpdir)
+
+    def read_tmux_commands(self) -> list[list[str]]:
+        lines = self.tmux_log.read_text(encoding="utf-8").splitlines()
+        return [line.split() for line in lines]
+
+    def test_codex_restore_sends_codex_resume_command(self):
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=self.env,
+        )
+
+        commands = self.read_tmux_commands()
+        self.assertIn(
+            ["send-keys", "-t", "codexfarm:proj", "codex", "resume", "--last", "C-m"],
+            commands,
+        )
+
+    def test_codex_restore_sends_claude_continue_command(self):
+        env = self.env.copy()
+        env["CODEX_TOOL_NAME"] = "claude"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        commands = self.read_tmux_commands()
+        self.assertIn(
+            ["send-keys", "-t", "codexfarm:proj", "claude", "--continue", "C-m"],
+            commands,
+        )
+
+    def test_codex_restore_sends_gemini_resume_command(self):
+        env = self.env.copy()
+        env["CODEX_TOOL_NAME"] = "gemini"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        commands = self.read_tmux_commands()
+        self.assertIn(
+            ["send-keys", "-t", "codexfarm:proj", "gemini", "--resume", "latest", "C-m"],
+            commands,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary
- send a tool-specific resume command into each restored tmux window after `codex-add` recreates it
- cover Codex, Claude, and Gemini restore behavior with tmux-based regression tests
- document the new restore behavior and add the matching design and implementation notes

## Why
Restoring a saved session recreated panes, but it did not resume the last CLI conversation inside each restored window.

## Validation
- `python3 -m pytest -q`
