### PR TITLE
[codex] Retry looper prompts after rate limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,14 @@ jobs:
       run: |
         for script in bin/codex-*; do
           echo "Checking $script..."
-          bash -n "$script"
+          shebang="$(head -n 1 "$script")"
+          if echo "$shebang" | grep -qE '^#!.*(env[[:space:]]+)?(ba)?sh([[:space:]]|$)'; then
+            bash -n "$script"
+          elif echo "$shebang" | grep -qE '^#!.*python'; then
+            PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile "$script"
+          else
+            echo "Skipping $script (unknown shebang)"
+          fi
         done
         
     - name: Test help messages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
     - name: Test help messages
       run: |
         export PATH="$HOME/bin:$PATH"
-        codex-adopt 2>&1 | grep -q "Usage:"
-        codex-board invalid 2>&1 | grep -q "Usage:"
-        codex-status invalid 2>&1 | grep -q "Usage:"
+        codex-looper --help 2>&1 | grep -q "Tiny coding-agent looper"
+        codex-board --help 2>&1 | grep -q "Usage:"
+        codex-status --help 2>&1 | grep -q "Usage:"
         
     - name: Test status commands
       run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A tmux session manager for running and restoring multiple Codex CLI instances, w
 - **Status updates**: Tracks RUN/READY/ERR in tmux metadata and notifies when a window becomes READY
 - **Memory warnings**: Flag tmux windows whose pane process trees exceed a chosen RSS threshold
 - **Autosave/autorestore (optional)**: Systemd user services to persist sessions across logins
-- **Prompt loopers**: Run repeated file-backed prompt sequences with timeout and rate-limit stop detection
+- **Prompt loopers**: Run repeated file-backed prompt sequences with timeout handling and rate-limit retries
 - **Tool wrappers**: `claude-*` and `gemini-*` commands use the same tmux workflow
 
 ## Quick Start

--- a/bin/codex-looper.py
+++ b/bin/codex-looper.py
@@ -44,6 +44,17 @@ DEFAULT_STOP_PATTERNS = [
     r"deadline exceeded",
     r"request aborted",
 ]
+RETRYABLE_STOP_REASON_PATTERN = re.compile(
+    r"rate[\s_-]*limit|"
+    r"\b429\b|"
+    r"too many requests|"
+    r"retry[\s_-]*after|"
+    r"back[\s_-]*off|"
+    r"quota exceeded|"
+    r"temporarily unavailable|"
+    r"overloaded",
+    re.IGNORECASE,
+)
 
 
 class ConfigError(ValueError):
@@ -266,6 +277,10 @@ def _match_text(text: str, patterns: list[re.Pattern[str]]) -> str | None:
     return None
 
 
+def is_retryable_stop_reason(reason: str) -> bool:
+    return bool(RETRYABLE_STOP_REASON_PATTERN.search(reason))
+
+
 def parse_output_line(
     *,
     line: str,
@@ -301,7 +316,9 @@ def parse_output_line(
         if event_type == "rate_limit_event":
             info = data.get("rate_limit_info", {})
             status = info.get("status") if isinstance(info, dict) else None
-            if status in {"allowed_warning", "rejected"} or status is None:
+            if status in {"allowed", "allowed_warning"}:
+                return parsed
+            if status == "rejected" or status is None:
                 parsed.stop_reason = f"rate limit event: status={status or 'unknown'}"
                 return parsed
 
@@ -567,59 +584,79 @@ async def run_loop(*, agent: AgentConfig, looper: LooperConfig, options: RunOpti
         print(f"\n===== loop {loop_number} / session {session_name} =====")
 
         for prompt_index, prompt in enumerate(prompts, start=1):
-            context = CommandContext(
-                prompt=prompt,
-                session=session_name,
-                session_id=session_id,
-                loop=loop_number,
-                prompt_index=prompt_index,
-                label=label,
-                run_dir=run_dir,
-            )
-            command = build_command(
-                agent=agent,
-                context=context,
-                is_first_prompt_in_session=first_prompt_in_session,
-            )
+            attempt_first_prompt_in_session = first_prompt_in_session
             first_prompt_in_session = False
+            retry_count = 0
             log_path = run_dir / f"loop-{loop_number:04d}__prompt-{prompt_index:03d}.log"
 
-            print(f"\n--- prompt {prompt_index}/{len(prompts)} ---")
-            print(f"$ {shlex.join(command)}")
+            while True:
+                context = CommandContext(
+                    prompt=prompt,
+                    session=session_name,
+                    session_id=session_id,
+                    loop=loop_number,
+                    prompt_index=prompt_index,
+                    label=label,
+                    run_dir=run_dir,
+                )
+                command = build_command(
+                    agent=agent,
+                    context=context,
+                    is_first_prompt_in_session=attempt_first_prompt_in_session,
+                )
 
-            if options.dry_run:
-                continue
+                print(f"\n--- prompt {prompt_index}/{len(prompts)} ---")
+                if retry_count:
+                    print(f"retry attempt: {retry_count}")
+                print(f"$ {shlex.join(command)}")
 
-            result = await run_command(
-                command=command,
-                cwd=agent.cwd,
-                env=agent.env,
-                timeout_seconds=looper.timeout_seconds,
-                log_path=log_path,
-                agent_kind=agent.kind,
-                patterns=patterns,
-                scan_stdout=(looper.scan_stdout_for_stop_patterns or agent.scan_stdout_for_stop_patterns),
-                kill_on_stop_pattern=looper.kill_on_stop_pattern,
-            )
+                if options.dry_run:
+                    break
 
-            if result.session_id:
-                session_id = result.session_id
-                if not looper.fresh_session_per_loop:
-                    persistent_session_id = session_id
+                result = await run_command(
+                    command=command,
+                    cwd=agent.cwd,
+                    env=agent.env,
+                    timeout_seconds=looper.timeout_seconds,
+                    log_path=log_path,
+                    agent_kind=agent.kind,
+                    patterns=patterns,
+                    scan_stdout=(
+                        looper.scan_stdout_for_stop_patterns or agent.scan_stdout_for_stop_patterns
+                    ),
+                    kill_on_stop_pattern=looper.kill_on_stop_pattern,
+                )
 
-            if result.stop_reason:
-                print(f"\nSTOP: {result.stop_reason}")
-                print(f"last log: {log_path}")
-                set_tmux_window_option(TMUX_STATE_OPTION, "READY")
-                set_tmux_window_option(TMUX_STOP_REASON_OPTION, result.stop_reason[:250])
-                return 0
+                if result.session_id:
+                    session_id = result.session_id
+                    if not looper.fresh_session_per_loop:
+                        persistent_session_id = session_id
 
-            if result.returncode not in (0, None) and not looper.ignore_nonzero:
-                print(f"\nSTOP: command exited with code {result.returncode}")
-                print(f"last log: {log_path}")
-                set_tmux_window_option(TMUX_STATE_OPTION, "ERR")
-                set_tmux_window_option(TMUX_STOP_REASON_OPTION, f"exit {result.returncode}")
-                return int(result.returncode or 1)
+                if result.stop_reason:
+                    if is_retryable_stop_reason(result.stop_reason):
+                        retry_count += 1
+                        if result.session_id or agent.kind == "claude":
+                            attempt_first_prompt_in_session = False
+                        print(f"\nRETRY: {result.stop_reason}")
+                        print(f"last log: {log_path}")
+                        print(f"sleeping {looper.sleep_seconds:g} seconds before retry")
+                        await asyncio.sleep(looper.sleep_seconds)
+                        continue
+
+                    print(f"\nSTOP: {result.stop_reason}")
+                    print(f"last log: {log_path}")
+                    set_tmux_window_option(TMUX_STATE_OPTION, "READY")
+                    set_tmux_window_option(TMUX_STOP_REASON_OPTION, result.stop_reason[:250])
+                    return 0
+
+                if result.returncode not in (0, None) and not looper.ignore_nonzero:
+                    print(f"\nSTOP: command exited with code {result.returncode}")
+                    print(f"last log: {log_path}")
+                    set_tmux_window_option(TMUX_STATE_OPTION, "ERR")
+                    set_tmux_window_option(TMUX_STOP_REASON_OPTION, f"exit {result.returncode}")
+                    return int(result.returncode or 1)
+
+                break
 
         print(f"\ncompleted loop {loop_number}")
 

--- a/bin/codex-restore
+++ b/bin/codex-restore
@@ -190,7 +190,8 @@ restore_all_registered() {
     if [ "$force_requested" -eq 1 ]; then
       restore_args+=("--force")
     fi
-    if CODEX_SESSION="$session" "$0" "${restore_args[@]}" "$manifest"; then
+    restore_args+=("$manifest")
+    if CODEX_SESSION="$session" "$0" "${restore_args[@]}"; then
       count=$((count + 1))
     else
       status=1

--- a/docs/looper.md
+++ b/docs/looper.md
@@ -124,13 +124,14 @@ scan_stdout_for_stop_patterns = true
 
 Available placeholders: `{prompt}`, `{session}`, `{session_id}`, `{loop}`, `{prompt_index}`, `{label}`, `{run_dir}`.
 
-## Stop Conditions
+## Retry And Stop Conditions
+
+The looper retries the current prompt after the configured `sleep_seconds` delay when it sees provider rate-limit, backoff, quota, temporary-unavailability, or overload signals. Informational rate-limit telemetry such as Claude `rate_limit_event` records with `status = "allowed"` or `status = "allowed_warning"` is ignored.
 
 The looper stops when it sees:
 
 - local per-prompt timeout
-- provider rate-limit or backoff signal
-- common timeout, overload, or quota wording
+- common timeout, deadline, or request-abort wording
 - nonzero command exit, unless `--ignore-nonzero` is set
 
 Logs are written under `.agent-looper/runs/<timestamp>__<label>/`.

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -150,7 +150,7 @@ esac
         self.assertEqual(len(new_window), 1, f"Unexpected tmux commands: {commands}")
         command = " ".join(new_window[0])
         self.assertIn("-t work", command)
-        self.assertIn(f"-c {target_dir}", command)
+        self.assertIn(f"-c {target_dir.resolve()}", command)
 
     def test_autoservice_choice_persist_no(self):
         target_dir = self.tmpdir / "proj3"

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -230,6 +230,22 @@ scan_stdout_for_stop_patterns = true
 
         self.assertIsNone(parsed.stop_reason)
 
+    def test_stop_signal_parsing_ignores_allowed_rate_limit_event(self) -> None:
+        patterns = self.looper.compile_stop_patterns([r"rate[\s_-]*limit"])
+
+        parsed = self.looper.parse_output_line(
+            line=(
+                '{"type":"rate_limit_event",'
+                '"rate_limit_info":{"status":"allowed","rateLimitType":"five_hour"}}\n'
+            ),
+            stream="stdout",
+            agent_kind="claude",
+            patterns=patterns,
+            scan_stdout=False,
+        )
+
+        self.assertIsNone(parsed.stop_reason)
+
     def test_stop_signal_parsing_detects_stderr_and_codex_thread_id(self) -> None:
         patterns = self.looper.compile_stop_patterns([r"rate\s*limit"])
 
@@ -316,6 +332,63 @@ scan_stdout_for_stop_patterns = true
         self.assertTrue(result.timed_out)
         self.assertEqual(result.stop_reason, "local timeout after 0.01 seconds")
         self.assertTrue(transport.closed)
+
+    def test_run_loop_retries_current_prompt_after_rate_limit_stop(self) -> None:
+        async def exercise() -> tuple[int, list[list[str]], list[float]]:
+            calls: list[list[str]] = []
+            sleeps: list[float] = []
+            original_run_command = self.looper.run_command
+            original_sleep = self.looper.asyncio.sleep
+
+            async def fake_run_command(**kwargs: object) -> object:
+                calls.append(list(kwargs["command"]))  # type: ignore[index]
+                if len(calls) == 1:
+                    return self.looper.ProcessResult(
+                        returncode=1,
+                        stop_reason="rate limit event: status=rejected",
+                    )
+                return self.looper.ProcessResult(returncode=0)
+
+            async def fake_sleep(seconds: float) -> None:
+                sleeps.append(seconds)
+
+            self.looper.run_command = fake_run_command
+            self.looper.asyncio.sleep = fake_sleep
+            try:
+                with tempfile.TemporaryDirectory() as td:
+                    root = Path(td)
+                    prompt_file = root / "prompts.md"
+                    prompt_file.write_text("hello\n", encoding="utf-8")
+                    agent = self.looper.AgentConfig(
+                        name="generic",
+                        kind="generic",
+                        cwd=root,
+                        first_command=["agent", "{prompt}"],
+                    )
+                    looper = self.looper.LooperConfig(
+                        prompt_file=prompt_file,
+                        log_dir=root / "runs",
+                        sleep_seconds=0.25,
+                        max_loops=1,
+                    )
+                    options = self.looper.RunOptions(
+                        agent_name="generic",
+                        config_path=root / "agent-looper.toml",
+                        label="retry-smoke",
+                    )
+
+                    result = await self.looper.run_loop(agent=agent, looper=looper, options=options)
+            finally:
+                self.looper.run_command = original_run_command
+                self.looper.asyncio.sleep = original_sleep
+
+            return result, calls, sleeps
+
+        result, calls, sleeps = asyncio.run(exercise())
+
+        self.assertEqual(result, 0)
+        self.assertEqual(calls, [["agent", "hello"], ["agent", "hello"]])
+        self.assertEqual(sleeps, [0.25])
 
 
 class LooperCliTests(unittest.TestCase):
@@ -497,7 +570,7 @@ set -euo pipefail
             self.assertEqual(config.read_text(encoding="utf-8"), "custom config\n")
             self.assertEqual(prompts.read_text(encoding="utf-8"), "custom prompt\n")
             lines = log.read_text(encoding="utf-8").splitlines()
-            self.assertIn(f"args=-d {tmpdir}", lines)
+            self.assertIn(f"args=-d {tmpdir.resolve()}", lines)
             name_line = next(line for line in lines if line.startswith("CODEX_NAME="))
             args_line = next(line for line in lines if line.startswith("CODEX_ARGS="))
             self.assertRegex(name_line, r"^CODEX_NAME=Looper_[0-9a-f]{6}$")


### PR DESCRIPTION
## Summary
- Retry the current looper prompt after retryable provider signals such as rate limits, 429s, backoff, quota, temporary unavailable, or overload responses.
- Ignore informational Claude `rate_limit_event` telemetry when its status is `allowed` or `allowed_warning`.
- Fix two validation blockers found while running the full suite: macOS physical temp-path assertions and `codex-restore --all-registered` empty-array handling.

## Root Cause
The looper treated Claude `rate_limit_event` output as a terminal stop condition, including `status="allowed"` telemetry that only reports current allowance state. Real retryable provider errors also stopped the whole looper instead of retrying the current prompt.

## Test Plan
- `python3 -m unittest tests.test_looper`
- `python3 -m unittest discover -s tests`