### PR TITLE
Fix looper handling of oversized JSONL output

### DIFF
--- a/bin/codex-looper.py
+++ b/bin/codex-looper.py
@@ -36,6 +36,7 @@ DEFAULT_TIMEOUT_SECONDS = 7200.0
 DEFAULT_MAX_LOOPS = 0
 DEFAULT_MAX_TRANSIENT_RETRIES = 12
 DEFAULT_RETRY_NOTIFY_AFTER_SECONDS = 300.0
+STREAM_READ_CHUNK_BYTES = 64 * 1024
 DEFAULT_SINGLE_PROMPT_FILE = Path("PROMPT.md")
 DEFAULT_SEQUENCE_PROMPT_FILE = Path("prompts.md")
 DEFAULT_COMPLETION_MARKER = r"EXIT_SIGNAL:\s*true"
@@ -776,34 +777,57 @@ async def run_command(
         if reader is None:
             return
         output_stream = sys.stdout if stream_name == "stdout" else sys.stderr
+
+        def handle_line(raw_line: bytes, log_file: TextIO) -> None:
+            text = raw_line.decode("utf-8", errors="replace")
+            result.output_bytes += len(raw_line)
+            _safe_stream_write(output_stream, text)
+            log_file.write(f"[{utc_stamp()}] {stream_name}: {text}")
+            log_file.flush()
+
+            if completion_pattern and completion_pattern.search(text):
+                result.completion_detected = True
+
+            parsed = parse_output_line(
+                line=text,
+                stream=stream_name,
+                agent_kind=agent_kind,
+                patterns=patterns,
+                scan_stdout=scan_stdout,
+            )
+            if parsed.session_id and not result.session_id:
+                result.session_id = parsed.session_id
+            if parsed.stop_reason and not result.stop_reason:
+                result.stop_reason = parsed.stop_reason
+                result.retry_after_seconds = parsed.retry_after_seconds
+                result.retry_kind = parsed.retry_kind
+                stop_event.set()
+
         with log_path.open("a", encoding="utf-8") as log_file:
-            while True:
-                chunk = await reader.readline()
-                if not chunk:
-                    break
-                text = chunk.decode("utf-8", errors="replace")
-                result.output_bytes += len(chunk)
-                _safe_stream_write(output_stream, text)
-                log_file.write(f"[{utc_stamp()}] {stream_name}: {text}")
+            pending = bytearray()
+            try:
+                while True:
+                    chunk = await reader.read(STREAM_READ_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    pending.extend(chunk)
+                    while True:
+                        newline_index = pending.find(b"\n")
+                        if newline_index < 0:
+                            break
+                        raw_line = bytes(pending[: newline_index + 1])
+                        del pending[: newline_index + 1]
+                        handle_line(raw_line, log_file)
+                if pending:
+                    handle_line(bytes(pending), log_file)
+            except Exception as exc:
+                message = f"local {stream_name} reader failed: {type(exc).__name__}: {exc}"
+                if not result.stop_reason:
+                    result.stop_reason = message
+                log_file.write(f"[{utc_stamp()}] {stream_name}_reader_error: {message}\n")
                 log_file.flush()
-
-                if completion_pattern and completion_pattern.search(text):
-                    result.completion_detected = True
-
-                parsed = parse_output_line(
-                    line=text,
-                    stream=stream_name,
-                    agent_kind=agent_kind,
-                    patterns=patterns,
-                    scan_stdout=scan_stdout,
-                )
-                if parsed.session_id and not result.session_id:
-                    result.session_id = parsed.session_id
-                if parsed.stop_reason and not result.stop_reason:
-                    result.stop_reason = parsed.stop_reason
-                    result.retry_after_seconds = parsed.retry_after_seconds
-                    result.retry_kind = parsed.retry_kind
-                    stop_event.set()
+                stop_event.set()
+                await _terminate_process_group(process)
 
     async def wait_for_stop() -> None:
         await stop_event.wait()
@@ -818,7 +842,8 @@ async def run_command(
         await asyncio.wait_for(process.wait(), timeout=timeout_seconds)
     except asyncio.TimeoutError:
         result.timed_out = True
-        result.stop_reason = f"local timeout after {timeout_seconds:g} seconds"
+        if not result.stop_reason:
+            result.stop_reason = f"local timeout after {timeout_seconds:g} seconds"
         await _terminate_process_group(process)
     finally:
         await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -503,6 +503,105 @@ scan_stdout_for_stop_patterns = true
         self.assertEqual(result.stop_reason, "local timeout after 0.01 seconds")
         self.assertTrue(transport.closed)
 
+    def test_run_command_drains_jsonl_line_larger_than_asyncio_default_limit(self) -> None:
+        async def exercise() -> tuple[object, str, int]:
+            large_text = "x" * (70 * 1024)
+            first_line = "{" + f'"type":"assistant","message":"{large_text}"' + "}\n"
+            second_line = '{"type":"result","subtype":"success"}\n'
+            script = (
+                "import sys\n"
+                f"sys.stdout.write({first_line!r})\n"
+                f"sys.stdout.write({second_line!r})\n"
+                "sys.stdout.flush()\n"
+            )
+
+            with tempfile.TemporaryDirectory() as td:
+                log_path = Path(td) / "run.log"
+                result = await self.looper.run_command(
+                    command=[sys.executable, "-c", script],
+                    cwd=Path(td),
+                    env={},
+                    timeout_seconds=1.0,
+                    log_path=log_path,
+                    agent_kind="claude",
+                    patterns=[],
+                    scan_stdout=False,
+                    kill_on_stop_pattern=True,
+                )
+                return result, log_path.read_text(encoding="utf-8"), len(first_line) + len(second_line)
+
+        result, log_text, expected_bytes = asyncio.run(exercise())
+
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.output_bytes, expected_bytes)
+        self.assertIn('"message":"xxxxxxxxxx', log_text)
+        self.assertIn('"type":"result"', log_text)
+
+    def test_run_command_reports_reader_failure_instead_of_waiting_for_timeout(self) -> None:
+        async def exercise() -> tuple[object, str]:
+            stderr = asyncio.StreamReader()
+            stderr.feed_eof()
+
+            class FailingReader:
+                async def read(self, size: int = -1) -> bytes:
+                    raise RuntimeError("stream exploded")
+
+                async def readline(self) -> bytes:
+                    raise RuntimeError("stream exploded")
+
+            class FakeProcess:
+                def __init__(self) -> None:
+                    self.pid = 12345
+                    self.returncode = None
+                    self.stdout = FailingReader()
+                    self.stderr = stderr
+                    self._done = asyncio.Event()
+
+                async def wait(self) -> int:
+                    await self._done.wait()
+                    return int(self.returncode or 0)
+
+            process = FakeProcess()
+            original_create = self.looper.asyncio.create_subprocess_exec
+            original_terminate = self.looper._terminate_process_group
+
+            async def fake_create_subprocess_exec(*args: object, **kwargs: object) -> FakeProcess:
+                return process
+
+            async def fake_terminate_process_group(fake_process: FakeProcess) -> None:
+                fake_process.returncode = -15
+                fake_process._done.set()
+                await fake_process.wait()
+
+            self.looper.asyncio.create_subprocess_exec = fake_create_subprocess_exec
+            self.looper._terminate_process_group = fake_terminate_process_group
+            try:
+                with tempfile.TemporaryDirectory() as td:
+                    log_path = Path(td) / "run.log"
+                    result = await self.looper.run_command(
+                        command=["failing-agent"],
+                        cwd=Path(td),
+                        env={},
+                        timeout_seconds=1.0,
+                        log_path=log_path,
+                        agent_kind="generic",
+                        patterns=[],
+                        scan_stdout=False,
+                        kill_on_stop_pattern=True,
+                    )
+                    return result, log_path.read_text(encoding="utf-8")
+            finally:
+                self.looper.asyncio.create_subprocess_exec = original_create
+                self.looper._terminate_process_group = original_terminate
+
+        result, log_text = asyncio.run(exercise())
+
+        self.assertEqual(result.returncode, -15)
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.stop_reason, "local stdout reader failed: RuntimeError: stream exploded")
+        self.assertIn("stdout_reader_error", log_text)
+
     def test_run_loop_retries_current_prompt_after_rate_limit_stop(self) -> None:
         async def exercise() -> tuple[int, list[list[str]], list[float], list[tuple[str, str]]]:
             calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- Replace `run_command` subprocess `readline()` draining with chunk reads and internal line framing so a single large Claude/Codex JSONL event cannot kill the stdout/stderr reader.
- Report reader task failures explicitly as `local <stream> reader failed: ...` and terminate the child instead of waiting for the prompt timeout.
- Add regressions for >65KB JSONL lines and reader failure handling.

## Test Plan
- `python3 -m pytest tests/test_looper.py -q -k "larger_than_asyncio_default_limit or reader_failure"`
- `python3 -m pytest tests/test_looper.py -q`
- `python3 -m pytest -q`
- `git diff --check`
- `./validate.sh`