### PR TITLE
[codex] fix looper task metadata stop false positives

### DIFF
--- a/codex_looper/hybrid.py
+++ b/codex_looper/hybrid.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-
 UUID_PATTERN = re.compile(
     r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
@@ -164,7 +163,9 @@ def assess_claude_hybrid_signals(
     assistant_event_seen = any(
         event.role == "assistant" or event.event_type == "assistant" for event in tail.events
     )
-    user_event_seen = any(event.role == "user" or event.event_type == "user" for event in tail.events)
+    user_event_seen = any(
+        event.role == "user" or event.event_type == "user" for event in tail.events
+    )
 
     normalized_state = pane_state.upper()
     if normalized_state == "ERR":

--- a/codex_looper/retry.py
+++ b/codex_looper/retry.py
@@ -37,6 +37,12 @@ RELATIVE_RETRY_DELAY_KEYS = (
     "resetAfter",
 )
 ABSOLUTE_RETRY_RESET_KEYS = ("resetsAt", "reset_at", "resetAt")
+INFORMATIONAL_SYSTEM_SUBTYPES = {
+    "task_notification",
+    "task_started",
+    "task_updated",
+    "thinking_tokens",
+}
 
 
 def _json_blob(value: Any) -> str:
@@ -220,6 +226,9 @@ def parse_output_line(
             and data.get("is_error") is not True
             and data.get("api_error_status") in {None, ""}
         ):
+            return parsed
+
+        if event_type == "system" and subtype in INFORMATIONAL_SYSTEM_SUBTYPES:
             return parsed
 
         error_like = (

--- a/tests/test_claude_hybrid.py
+++ b/tests/test_claude_hybrid.py
@@ -11,7 +11,6 @@ from codex_looper.hybrid import (
     tmux_prompt_paste_commands,
 )
 
-
 SESSION_ID = "54f5b65c-a31c-4aa1-b91b-896b35e2a759"
 
 

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -1064,9 +1064,9 @@ fresh_session_per_loop = "false"
                     state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
                     events = [
                         json.loads(line)
-                        for line in (
-                            run_dir / "events.jsonl"
-                        ).read_text(encoding="utf-8").splitlines()
+                        for line in (run_dir / "events.jsonl")
+                        .read_text(encoding="utf-8")
+                        .splitlines()
                     ]
                     return result, state, events
             finally:

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -448,6 +448,39 @@ fresh_session_per_loop = "false"
 
         self.assertIsNone(parsed.stop_reason)
 
+    def test_stop_signal_parsing_ignores_claude_task_metadata_timeout_text(self) -> None:
+        patterns = self.looper.compile_stop_patterns(self.looper.DEFAULT_STOP_PATTERNS)
+        lines = [
+            {
+                "type": "system",
+                "subtype": "task_started",
+                "task_id": "abc123",
+                "tool_use_id": "toolu_123",
+                "description": "Run focused tests with timeout",
+                "task_type": "local_bash",
+            },
+            {
+                "type": "system",
+                "subtype": "task_notification",
+                "task_id": "abc123",
+                "tool_use_id": "toolu_123",
+                "status": "stopped",
+                "summary": "Run focused tests with timeout",
+            },
+        ]
+
+        for line in lines:
+            with self.subTest(subtype=line["subtype"]):
+                parsed = self.looper.parse_output_line(
+                    line=json.dumps(line),
+                    stream="stdout",
+                    agent_kind="claude",
+                    patterns=patterns,
+                    scan_stdout=False,
+                )
+
+                self.assertIsNone(parsed.stop_reason)
+
     def test_stop_signal_parsing_ignores_allowed_rate_limit_event(self) -> None:
         patterns = self.looper.compile_stop_patterns([r"rate[\s_-]*limit"])
 

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -688,6 +688,7 @@ fresh_session_per_loop = "false"
                     patterns=[],
                     scan_stdout=False,
                     kill_on_stop_pattern=True,
+                    stream_output=False,
                 )
                 return (
                     result,

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -2,6 +2,7 @@ import json
 import os
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -91,7 +92,7 @@ esac
             (run_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
             bin_dir = project / "bin"
             bin_dir.mkdir()
-            (bin_dir / "python3").symlink_to("/usr/local/bin/python3.12")
+            (bin_dir / "python3").symlink_to(sys.executable)
             env = os.environ.copy()
             env["PATH"] = str(bin_dir)
 

--- a/tests/test_status_script.py
+++ b/tests/test_status_script.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 import stat
 import subprocess
 import tempfile


### PR DESCRIPTION
## Summary

Fixes a codex-looper false positive where benign Claude structured `system` task lifecycle events could stop the loop when their task description or summary contained text like `timeout`.

## Root Cause

`parse_output_line` treated all structured `system` events as error-like and scanned the entire JSON blob for stop patterns. Claude task metadata such as `task_started.description` and `task_notification.summary` can legitimately contain words like `timeout`, causing the looper to terminate the provider process even though the configured wall-clock timeout had not fired.

## Changes

- Treat Claude task lifecycle and token-progress `system` events as informational for stop-pattern parsing.
- Add a regression test covering `task_started.description` and `task_notification.summary` containing `timeout`.
- Apply CI-required Ruff formatting/import cleanup and make the status-script test portable across GitHub runner Python paths.
- Avoid streaming the synthetic 70 KiB JSONL line in the large-line drain test while still verifying the internal log drain path.

## Validation

Local:
- `python3.12 -m pytest tests/test_looper.py::LooperCoreTests::test_stop_signal_parsing_ignores_claude_task_metadata_timeout_text -q`
- `python3.12 -m pytest tests/test_looper.py -q`
- `python3.12 -m pytest -q`
- `python3.12 -m ruff format --check .`
- `python3.12 -m ruff check .`
- `python3.12 -m unittest discover -s tests -v`
- `./validate.sh`

GitHub Actions:
- `Test Codex CLI Farm / test (3.10)` passed
- `Test Codex CLI Farm / test (3.13)` passed