### PR TITLE
Fix farm session restore reliability

### DIFF
--- a/bin/codex-add
+++ b/bin/codex-add
@@ -565,8 +565,10 @@ if [ "$install_autoservice_only" -eq 1 ]; then
 fi
 
 STAMP=$(date +%Y%m%d-%H%M%S)
-LOGFILE="$LOGDIR/$(safe_name "$NAME")_${STAMP}.log"
-( umask 077; : > "$LOGFILE" )
+log_seed=$(mktemp "$LOGDIR/.codexfarm-log.XXXXXX")
+log_token="${log_seed##*.codexfarm-log.}"
+LOGFILE="$LOGDIR/$(safe_name "$NAME")_${STAMP}_${log_token}.log"
+mv "$log_seed" "$LOGFILE"
 chmod 600 "$LOGFILE" 2>/dev/null || true
 
 # Create session if it doesn't exist

--- a/bin/codex-annotator.py
+++ b/bin/codex-annotator.py
@@ -119,6 +119,7 @@ class PaneInfo:
     current_command: str
     dead: bool
     start_command: str = ""
+    process_pid: str = ""
 
 
 def log(msg: str, *, verbose: bool) -> None:
@@ -213,7 +214,10 @@ def window_pane_states(wid: str, *, verbose: bool) -> list[PaneInfo] | None:
             "-t",
             wid,
             "-F",
-            "#{pane_id}\t#{pane_current_command}\t#{pane_dead}\t#{pane_start_command}",
+            (
+                "#{pane_id}\t#{pane_current_command}\t#{pane_dead}\t"
+                "#{pane_start_command}\t#{pane_pid}"
+            ),
         ],
         verbose=verbose,
     )
@@ -223,18 +227,23 @@ def window_pane_states(wid: str, *, verbose: bool) -> list[PaneInfo] | None:
     for line in output.splitlines():
         if line.count("\t") < 2:
             continue
-        parts = line.split("\t", 3)
+        parts = line.split("\t", 4)
         if len(parts) == 3:
             pid, cmd, dead = parts
             start_command = cmd
-        else:
+            process_pid = ""
+        elif len(parts) == 4:
             pid, cmd, dead, start_command = parts
+            process_pid = ""
+        else:
+            pid, cmd, dead, start_command, process_pid = parts
         panes.append(
             PaneInfo(
                 pid=pid.strip(),
                 current_command=cmd.strip(),
                 dead=dead.strip() in {"1", "true", "True"},
                 start_command=start_command.strip(),
+                process_pid=process_pid.strip(),
             )
         )
     return panes
@@ -257,6 +266,50 @@ def is_looper_command(cmd: str) -> bool:
     )
 
 
+def process_tree_command_context(root_pid: str) -> str:
+    """Return command names/argv for a pane process and its descendants."""
+    if not root_pid.isdigit():
+        return ""
+
+    try:
+        process = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,comm=,args="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=1,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+    if process.returncode != 0:
+        return ""
+
+    process_commands: dict[str, str] = {}
+    child_pids: dict[str, list[str]] = {}
+    for line in process.stdout.splitlines():
+        parts = line.strip().split(None, 3)
+        if len(parts) < 3:
+            continue
+        pid, parent_pid, command = parts[:3]
+        args = parts[3] if len(parts) == 4 else ""
+        process_commands[pid] = f"{command} {args}".strip()
+        child_pids.setdefault(parent_pid, []).append(pid)
+
+    pending = [root_pid]
+    seen = {root_pid}
+    commands: list[str] = []
+    while pending and len(seen) <= 256:
+        pid = pending.pop(0)
+        command = process_commands.get(pid)
+        if command:
+            commands.append(command)
+        for child in child_pids.get(pid, []):
+            if child not in seen:
+                seen.add(child)
+                pending.append(child)
+    return " ".join(commands)
+
+
 def classify_pane(
     pane: PaneInfo,
     running_regex: re.Pattern,
@@ -268,10 +321,26 @@ def classify_pane(
     command_context = f"{pane.current_command} {pane.start_command}".strip()
     if is_looper_command(command_context):
         return "RUN"
-    if is_codex_command(command_context):
+    provider_context = command_context
+    current_command_parts = pane.current_command.split()
+    current_command_name = (
+        Path(current_command_parts[0]).name.lower() if current_command_parts else ""
+    )
+    if (
+        pane.process_pid
+        and current_command_name in {"node", "nodejs"}
+        and not is_codex_command(provider_context)
+        and not is_claude_command(provider_context)
+    ):
+        descendant_context = process_tree_command_context(pane.process_pid)
+        if descendant_context:
+            provider_context = f"{provider_context} {descendant_context}".strip()
+    if is_looper_command(provider_context):
+        return "RUN"
+    if is_codex_command(provider_context):
         output = capture_pane_output(pane.pid, verbose=verbose)
         return classify_codex_output(output)
-    if is_claude_command(command_context):
+    if is_claude_command(provider_context):
         output = capture_pane_output(pane.pid, verbose=verbose)
         return classify_claude_output(output)
     if running_regex.search(command_context):

--- a/bin/codex-restore
+++ b/bin/codex-restore
@@ -82,7 +82,7 @@ existing_window_target() {
       printf '%s' "$target"
       return 0
     fi
-  done < <(tmux list-windows -t "$session" -F '#{window_id}\t#{window_name}')
+  done < <(tmux list-windows -t "$session" -F $'#{window_id}\t#{window_name}')
 
   return 1
 }

--- a/bin/codex-save
+++ b/bin/codex-save
@@ -89,7 +89,7 @@ session_file_matches_tool() {
   local tool="$1"
   local path="$2"
   case "$tool:$path" in
-    codex:*/.codex/sessions/*.jsonl)
+    codex:*/.codex/sessions/*.jsonl|codex:*/sessions/*/rollout-*.jsonl)
       return 0
       ;;
     claude:*/.claude/projects/*.jsonl)
@@ -134,14 +134,54 @@ descendant_pids() {
   done
 }
 
-session_id_from_lsof() {
+session_id_from_procfs() {
+  local tool="$1"
+  local pid="$2"
+  local descriptor path session_id
+  local proc_root="${CODEX_PROC_ROOT:-/proc}"
+  [ -d "$proc_root/$pid/fd" ] || return 1
+
+  for descriptor in "$proc_root/$pid/fd"/*; do
+    [ -e "$descriptor" ] || [ -L "$descriptor" ] || continue
+    path="$(readlink "$descriptor" 2>/dev/null || true)"
+    path="${path% (deleted)}"
+    if session_file_matches_tool "$tool" "$path"; then
+      session_id="$(session_id_from_path "$path" || true)"
+      if [ -n "$session_id" ]; then
+        printf '%s' "$session_id"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+session_id_from_process_files() {
   local tool="$1"
   local pane_pid="$2"
+  local provider_pid="${3:-}"
   local pid line path session_id
+  local pids=()
   [ -n "$pane_pid" ] || return 1
-  command -v lsof >/dev/null 2>&1 || return 1
 
-  while IFS= read -r pid; do
+  if [ -n "$provider_pid" ]; then
+    pids+=("$provider_pid")
+  else
+    while IFS= read -r pid; do
+      [ -n "$pid" ] && pids+=("$pid")
+    done < <(descendant_pids "$pane_pid")
+  fi
+
+  for pid in "${pids[@]}"; do
+    session_id="$(session_id_from_procfs "$tool" "$pid" || true)"
+    if [ -n "$session_id" ]; then
+      printf '%s' "$session_id"
+      return 0
+    fi
+  done
+
+  command -v lsof >/dev/null 2>&1 || return 1
+  for pid in "${pids[@]}"; do
     [ -z "$pid" ] && continue
     while IFS= read -r line; do
       case "$line" in
@@ -157,7 +197,7 @@ session_id_from_lsof() {
           ;;
       esac
     done < <(lsof -Fn -p "$pid" 2>/dev/null || true)
-  done < <(descendant_pids "$pane_pid")
+  done
 
   return 1
 }
@@ -176,11 +216,87 @@ tool_from_command() {
   return 1
 }
 
+tool_from_process_argv() {
+  local token base
+  local tokens=()
+  read -r -a tokens <<< "$1"
+  for token in "${tokens[@]}"; do
+    token="${token#\"}"
+    token="${token%\"}"
+    token="${token#\'}"
+    token="${token%\'}"
+    base="${token##*/}"
+    case "$base" in
+      codex|claude|gemini)
+        printf '%s' "$base"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+tool_from_process_tree() {
+  local pane_pid="$1"
+  local pid value tool
+  [ -n "$pane_pid" ] || return 1
+  command -v ps >/dev/null 2>&1 || return 1
+
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    value="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
+    tool="$(tool_from_command "$value" || true)"
+    if [ -n "$tool" ]; then
+      printf '%s' "$tool"
+      return 0
+    fi
+
+    value="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+    tool="$(tool_from_process_argv "$value" || true)"
+    if [ -n "$tool" ]; then
+      printf '%s' "$tool"
+      return 0
+    fi
+  done < <(descendant_pids "$pane_pid")
+
+  return 1
+}
+
+provider_pid_from_process_tree() {
+  local tool="$1"
+  local pane_pid="$2"
+  local pid value detected fallback=""
+  [ -n "$pane_pid" ] || return 1
+  command -v ps >/dev/null 2>&1 || return 1
+
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    value="$(ps -p "$pid" -o comm= 2>/dev/null || true)"
+    detected="$(tool_from_command "$value" || true)"
+    if [ "$detected" = "$tool" ]; then
+      printf '%s' "$pid"
+      return 0
+    fi
+
+    if [ -z "$fallback" ]; then
+      value="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+      detected="$(tool_from_process_argv "$value" || true)"
+      if [ "$detected" = "$tool" ]; then
+        fallback="$pid"
+      fi
+    fi
+  done < <(descendant_pids "$pane_pid")
+
+  [ -n "$fallback" ] || return 1
+  printf '%s' "$fallback"
+}
+
 resume_args_for_pane() {
   local tool="$1"
   local pane_pid="$2"
+  local provider_pid="${3:-}"
   local session_id
-  session_id="$(session_id_from_lsof "$tool" "$pane_pid" || true)"
+  session_id="$(session_id_from_process_files "$tool" "$pane_pid" "$provider_pid" || true)"
   case "$tool" in
     codex)
       if [ -n "$session_id" ]; then
@@ -323,23 +439,34 @@ while IFS=$'\n' read -r idx; do
   [ "$name" = "home" ] && continue
   # Prefer the first pane's path
   dir=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_current_path}')
-  # Best-effort: starting command (may be sh/bash)
+  # Best-effort: starting command (often sh/bash for a long-lived pane)
   cmd=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_start_command}')
+  current_cmd=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_current_command}')
   pane_pid=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_pid}')
   args=
   tool="$(tool_from_command "$cmd" || true)"
+  if [ -z "$tool" ]; then
+    tool="$(tool_from_command "$current_cmd" || true)"
+  fi
+  if [ -z "$tool" ]; then
+    tool="$(tool_from_process_tree "$pane_pid" || true)"
+  fi
+  provider_pid=""
+  if [ -n "$tool" ]; then
+    provider_pid="$(provider_pid_from_process_tree "$tool" "$pane_pid" || true)"
+  fi
   case "$tool" in
     codex)
       cmd="codex"
-      args="$(resume_args_for_pane "$tool" "$pane_pid")"
+      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
       ;;
     claude)
       cmd="claude"
-      args="$(resume_args_for_pane "$tool" "$pane_pid")"
+      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
       ;;
     gemini)
       cmd="gemini"
-      args="$(resume_args_for_pane "$tool" "$pane_pid")"
+      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
       ;;
     *)
       cmd=$(trim_command_field "$cmd")

--- a/codex_looper/agents.py
+++ b/codex_looper/agents.py
@@ -27,9 +27,7 @@ def agent_extra_args(agent: AgentConfig) -> list[str]:
         args.extend(["--model", agent.model])
     if agent.effort:
         if agent.kind == "codex":
-            args.extend(
-                ["--config", f"model_reasoning_effort={json.dumps(agent.effort)}"]
-            )
+            args.extend(["--config", f"model_reasoning_effort={json.dumps(agent.effort)}"])
         elif agent.kind == "claude":
             args.extend(["--effort", agent.effort])
     return args

--- a/codex_looper/agents.py
+++ b/codex_looper/agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from string import Formatter
 
 from .models import AgentConfig, CommandContext, CommandTemplateError
@@ -25,7 +26,12 @@ def agent_extra_args(agent: AgentConfig) -> list[str]:
     if agent.model:
         args.extend(["--model", agent.model])
     if agent.effort:
-        args.extend(["--effort", agent.effort])
+        if agent.kind == "codex":
+            args.extend(
+                ["--config", f"model_reasoning_effort={json.dumps(agent.effort)}"]
+            )
+        elif agent.kind == "claude":
+            args.extend(["--effort", agent.effort])
     return args
 
 

--- a/codex_looper/cli.py
+++ b/codex_looper/cli.py
@@ -574,19 +574,23 @@ def control_main(argv: list[str] | None = None) -> int:
         return 0
 
     print(f"queued {record['action']} for {target} at {run_dir}")
+    if args.force or args.now:
+        state_path = run_dir / "state.json"
+        try:
+            state, repaired, stale_reason = repair_stale_state_file(state_path)
+        except Exception as exc:
+            print(f"stale-state repair failed: {exc}", file=sys.stderr)
+            return 2
+        else:
+            if repaired and stale_reason:
+                print(f"repaired stale looper state: {stale_reason}")
+                return 0
+
     if args.force:
         results = force_stop_from_state(state, grace_seconds=args.grace_seconds)
         detail = format_stop_signal_results(results)
         if detail:
             print(detail)
-        state_path = run_dir / "state.json"
-        try:
-            _, repaired, stale_reason = repair_stale_state_file(state_path)
-        except Exception as exc:
-            print(f"stale-state repair failed: {exc}", file=sys.stderr)
-        else:
-            if repaired and stale_reason:
-                print(f"repaired stale looper state: {stale_reason}")
     elif args.now:
         detail = interrupt_from_state(state)
         if detail:

--- a/codex_looper/control.py
+++ b/codex_looper/control.py
@@ -304,13 +304,11 @@ def select_control_run(
             or Path(str(state.get("run_dir") or "")).name == label
         ]
     if not include_stopped:
-        active = [
+        candidates = [
             state
             for state in candidates
             if str(state.get("status") or "") in {"running", "retrying"}
         ]
-        if active:
-            candidates = active
     if not candidates:
         target = label or str(state_root)
         raise ControlError(f"no matching looper run found for {target}")

--- a/codex_looper/control_panel.py
+++ b/codex_looper/control_panel.py
@@ -162,7 +162,13 @@ def run_control_pane_action(
             action="interrupt_now",
             reason="control pane: interrupt now",
         )
-        detail = interrupt_from_state(_state_for_signals(run_dir))
+        try:
+            state, repaired, stale_reason = repair_stale_state_file(run_dir / STATE_FILENAME)
+        except Exception as exc:
+            return ControlPaneActionResult(f"stale-state repair failed: {exc}")
+        if repaired and stale_reason:
+            return ControlPaneActionResult(f"repaired stale looper state: {stale_reason}")
+        detail = interrupt_from_state(state)
         return ControlPaneActionResult(detail or "queued interrupt_now")
     if key == "f":
         append_control_command(
@@ -170,18 +176,17 @@ def run_control_pane_action(
             action="interrupt_now",
             reason="control pane: force stop",
         )
+        try:
+            state, repaired, stale_reason = repair_stale_state_file(run_dir / STATE_FILENAME)
+        except Exception as exc:
+            return ControlPaneActionResult(f"stale-state repair failed: {exc}")
+        if repaired and stale_reason:
+            return ControlPaneActionResult(f"repaired stale looper state: {stale_reason}")
         results = force_stop_from_state(
-            _state_for_signals(run_dir),
+            state,
             grace_seconds=force_grace_seconds,
         )
         detail = format_stop_signal_results(results) or "queued force stop"
-        try:
-            _, repaired, stale_reason = repair_stale_state_file(run_dir / STATE_FILENAME)
-        except Exception as exc:
-            detail = f"{detail}\nstale-state repair failed: {exc}"
-        else:
-            if repaired and stale_reason:
-                detail = f"{detail}\nrepaired stale looper state: {stale_reason}"
         return ControlPaneActionResult(detail)
     if key == "r":
         try:

--- a/codex_looper/process.py
+++ b/codex_looper/process.py
@@ -31,13 +31,35 @@ def _safe_stream_write(stream: TextIO, text: str) -> None:
 
 
 async def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except Exception:
+            if process.returncode is not None:
+                return
+            process.terminate()
+
+        deadline = asyncio.get_running_loop().time() + 10
+        while process.returncode is None and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except Exception:
+            if process.returncode is None:
+                process.kill()
+        if process.returncode is None:
+            await process.wait()
+        return
+
     if process.returncode is not None:
         return
     try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGTERM)
-        else:
-            process.terminate()
+        process.terminate()
     except ProcessLookupError:
         return
     except Exception:
@@ -50,10 +72,7 @@ async def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
         pass
 
     try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGKILL)
-        else:
-            process.kill()
+        process.kill()
     except ProcessLookupError:
         return
     except Exception:
@@ -196,7 +215,17 @@ async def run_command(
             result.stop_reason = f"local timeout after {timeout_seconds:g} seconds"
         await terminate_process_group(process)
     finally:
-        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        stream_tasks = asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        try:
+            await asyncio.wait_for(asyncio.shield(stream_tasks), timeout=1)
+        except asyncio.TimeoutError:
+            await terminate_process_group(process)
+            try:
+                await asyncio.wait_for(asyncio.shield(stream_tasks), timeout=1)
+            except asyncio.TimeoutError:
+                stdout_task.cancel()
+                stderr_task.cancel()
+                await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
         if not stop_task.done():
             stop_task.cancel()
             await asyncio.gather(stop_task, return_exceptions=True)

--- a/codex_looper/runner.py
+++ b/codex_looper/runner.py
@@ -63,6 +63,7 @@ from .retry import (
     transient_retry_limit_reached,
 )
 from .state import LooperStateRecorder
+from .status_state import process_identity
 from .tmux import (
     display_tmux_message,
     set_tmux_window_option,
@@ -423,6 +424,7 @@ async def run_loop(
             "control_last_reason": None,
             "control_last_id": None,
             "pid": os.getpid(),
+            "pid_identity": process_identity(os.getpid()),
             "child_pid": None,
             "child_pgid": None,
             "hybrid_pane_id": None,

--- a/codex_looper/status_state.py
+++ b/codex_looper/status_state.py
@@ -98,9 +98,9 @@ def process_identity(pid: int) -> str | None:
             start_time = _parse_linux_proc_start_time(stat_text)
             if start_time:
                 try:
-                    boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
-                        encoding="utf-8"
-                    ).strip()
+                    boot_id = (
+                        Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+                    )
                 except (FileNotFoundError, PermissionError, OSError):
                     boot_id = "unknown-boot"
                 return f"linux-proc:{boot_id}:{start_time}"

--- a/codex_looper/status_state.py
+++ b/codex_looper/status_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,6 +58,16 @@ def _parse_linux_proc_state(stat_text: str) -> str | None:
     return fields[0]
 
 
+def _parse_linux_proc_start_time(stat_text: str) -> str | None:
+    command_end = stat_text.rfind(")")
+    if command_end < 0:
+        return None
+    fields = stat_text[command_end + 1 :].strip().split()
+    if len(fields) <= 19:
+        return None
+    return fields[19]
+
+
 def _linux_proc_state(pid: int) -> str | None:
     try:
         stat_text = (Path("/proc") / str(pid) / "stat").read_text(encoding="utf-8")
@@ -79,6 +90,37 @@ def process_is_running(pid: int) -> bool:
     return True
 
 
+def process_identity(pid: int) -> str | None:
+    """Return a stable creation token so a reused PID is not mistaken for a run."""
+    if os.name == "posix":
+        try:
+            stat_text = (Path("/proc") / str(pid) / "stat").read_text(encoding="utf-8")
+            start_time = _parse_linux_proc_start_time(stat_text)
+            if start_time:
+                try:
+                    boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+                        encoding="utf-8"
+                    ).strip()
+                except (FileNotFoundError, PermissionError, OSError):
+                    boot_id = "unknown-boot"
+                return f"linux-proc:{boot_id}:{start_time}"
+        except (FileNotFoundError, PermissionError, OSError):
+            pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=1,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    started_at = result.stdout.strip()
+    return f"ps-lstart:{started_at}" if result.returncode == 0 and started_at else None
+
+
 def active_state_stale_reason(state: Mapping[str, Any]) -> str | None:
     status = str(state.get("status") or "")
     if status not in ACTIVE_RUN_STATUSES:
@@ -86,9 +128,14 @@ def active_state_stale_reason(state: Mapping[str, Any]) -> str | None:
     supervisor_pid = _coerce_pid(state.get("pid"))
     if supervisor_pid is None:
         return "active looper state has no supervisor pid"
-    if process_is_running(supervisor_pid):
-        return None
-    return f"supervisor process {supervisor_pid} is no longer running"
+    if not process_is_running(supervisor_pid):
+        return f"supervisor process {supervisor_pid} is no longer running"
+    expected_identity = str(state.get("pid_identity") or "")
+    if expected_identity:
+        current_identity = process_identity(supervisor_pid)
+        if current_identity and current_identity != expected_identity:
+            return f"supervisor process {supervisor_pid} identity changed"
+    return None
 
 
 def stopped_state_from_stale(

--- a/docs/looper.md
+++ b/docs/looper.md
@@ -74,7 +74,7 @@ codex-looper --mode sequence --prompt-file prompts.md --once
 claude-looper --complete-on 'EXIT_SIGNAL:\s*true' --plan-file fix_plan.md --backup
 codex-looper --cb-no-progress 3 --cb-output-decline 2 --backup --backup-keep 20
 codex-looper --preset rai
-codex-looper --once --label gpt5-high -- --model gpt-5.4 --effort high
+codex-looper --once --label gpt5-high -- --model gpt-5.4 --config 'model_reasoning_effort="high"'
 claude-looper --once --label smoke -- --dangerously-skip-permissions
 codex-looper --farm-session work --label cleanup --cwd /path/to/project
 codex-looper --local --once --label local-preview
@@ -172,7 +172,7 @@ Agent defaults:
 | `claude` | Default hybrid: start a visible `claude` TTY pane, paste prompts, and detect turn completion from Claude session JSONL terminal events plus pane readiness. With `fresh_session_per_loop = true`, replace the pane/process between loops; otherwise reuse it. With `interface = "json"`: first prompt uses `claude -p --output-format stream-json --verbose --name <session> <prompt>`; later prompts use `--resume <session>`. |
 | `gemini` | Generic default: `gemini -p <prompt>` for every prompt. Override this if your Gemini CLI supports a better noninteractive/resume mode. |
 
-Built-in Codex and Claude agents accept `model` and `effort` config sugar. These fields are appended after `extra_args` as `--model <value>` and `--effort <value>`:
+Built-in Codex and Claude agents accept `model` and `effort` config sugar. `model` is appended after `extra_args` as `--model <value>`. Claude receives effort as `--effort <value>`; Codex receives it through `--config model_reasoning_effort="<value>"`, which is the Codex CLI's supported form:
 
 ```toml
 [agents.codex]

--- a/tests/integration/deep_history_smoke.sh
+++ b/tests/integration/deep_history_smoke.sh
@@ -89,10 +89,18 @@ assert pathlib.Path(sys.argv[2]).stat().st_mode & 0o777 == 0o600
 PY
 
 "$DEEP_HISTORY_BIN" stop -t "$PANE_ID"
-for _ in $(seq 1 100); do
-    grep -q '"status": "closed"' "$RUN_DIR/metadata.json" 2>/dev/null && break
+CLOSED=0
+for _ in $(seq 1 200); do
+    if grep -q '"status": "closed"' "$RUN_DIR/metadata.json" 2>/dev/null; then
+        CLOSED=1
+        break
+    fi
     sleep 0.05
 done
-grep -q '"status": "closed"' "$RUN_DIR/metadata.json"
+if [[ "$CLOSED" != "1" ]]; then
+    printf '%s\n' 'deep-history metadata did not close within 10 seconds' >&2
+    cat "$RUN_DIR/metadata.json" >&2 || true
+    exit 1
+fi
 
 printf '%s\n' 'agent-cli-farm deep-history integration test passed'

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -138,6 +138,28 @@ esac
         ]
         self.assertEqual(title_lock_commands, [], f"Unexpected title locks: {commands}")
 
+    def test_codex_add_uses_unique_logs_for_same_name_and_second(self):
+        target_dir = self.tmpdir / "same-name"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        make_executable(
+            self.tmpdir / "date",
+            "#!/usr/bin/env bash\nprintf '20260715-120000\\n'\n",
+        )
+        env = self.env.copy()
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+
+        for _ in range(2):
+            subprocess.run(
+                [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+                check=True,
+                env=env,
+            )
+
+        log_files = list((Path(env["XDG_STATE_HOME"]) / "codexfarm" / "logs").glob("*.log"))
+        self.assertEqual(len(log_files), 2)
+        self.assertEqual(len({path.name for path in log_files}), 2)
+        self.assertTrue(all(path.stat().st_mode & 0o777 == 0o600 for path in log_files))
+
     def test_codex_add_keeps_window_after_command_exit_by_default(self):
         target_dir = self.tmpdir / "proj-remain"
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -524,6 +546,10 @@ class SaveScriptTests(unittest.TestCase):
             "/home/test/.codex/sessions/2026/05/11/"
             "rollout-2026-05-11T03-23-27-019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4.jsonl"
         )
+        self.codex_session_path = codex_session_path
+        self.custom_codex_session_path = codex_session_path.replace(
+            "/home/test/.codex", "/srv/custom-codex-home"
+        )
         claude_session_path = (
             "/home/test/.claude/projects/-tmp-project/54f5b65c-a31c-4aa1-b91b-896b35e2a759.jsonl"
         )
@@ -571,7 +597,9 @@ case "$1" in
         ;;
       *:1.0'|#{pane_current_path}') printf '/tmp/project\\n' ;;
       *:1.0'|#{pane_start_command}')
-        if [ "${WRAPPED_CODEX_START:-0}" = "1" ]; then
+        if [ "${SHELL_STARTED_CODEX:-0}" = "1" ]; then
+          printf '\\n'
+        elif [ "${WRAPPED_CODEX_START:-0}" = "1" ]; then
           printf 'tmux set-window-option -q remain-on-exit on >/dev/null 2>&1 || true; exec codex\\n'
         elif [ "${QUOTED_CODEX_START:-0}" = "1" ]; then
           printf '"codex "\\n'
@@ -579,14 +607,17 @@ case "$1" in
           printf 'codex\\n'
         fi
         ;;
+      *:1.0'|#{pane_current_command}') printf 'node\\n' ;;
       *:1.0'|#{pane_pid}') printf '100\\n' ;;
       *:2'|#{window_name}') printf 'claude-proj\\n' ;;
       *:2.0'|#{pane_current_path}') printf '/tmp/claude-project\\n' ;;
       *:2.0'|#{pane_start_command}') printf 'claude\\n' ;;
+      *:2.0'|#{pane_current_command}') printf 'node\\n' ;;
       *:2.0'|#{pane_pid}') printf '200\\n' ;;
       *:3'|#{window_name}') printf 'gemini-proj\\n' ;;
       *:3.0'|#{pane_current_path}') printf '/tmp/gemini-project\\n' ;;
       *:3.0'|#{pane_start_command}') printf 'gemini\\n' ;;
+      *:3.0'|#{pane_current_command}') printf 'node\\n' ;;
       *:3.0'|#{pane_pid}') printf '300\\n' ;;
       *) exit 1 ;;
     esac
@@ -630,6 +661,29 @@ esac
         make_executable(self.tmpdir / "tmux", tmux_stub)
         make_executable(self.tmpdir / "pgrep", pgrep_stub)
         make_executable(self.tmpdir / "lsof", lsof_stub)
+        make_executable(
+            self.tmpdir / "ps",
+            """#!/usr/bin/env bash
+set -euo pipefail
+pid=""
+format=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) pid="$2"; shift 2 ;;
+    -o) format="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "${SHELL_STARTED_CODEX:-0}" = "1" ]; then
+  case "$pid|$format" in
+    100'|comm=') printf 'bash\\n' ;;
+    100'|args=') printf 'bash\\n' ;;
+    101'|comm=') printf 'codex\\n' ;;
+    101'|args=') printf '/usr/local/bin/codex\\n' ;;
+  esac
+fi
+""",
+        )
 
         self.env = os.environ.copy()
         self.env["PATH"] = f"{self.tmpdir}:{self.env.get('PATH', '')}"
@@ -659,6 +713,27 @@ esac
             rows,
         )
         self.assertEqual(stat.S_IMODE(self.manifest.stat().st_mode), 0o600)
+
+    def test_codex_save_finds_custom_home_session_for_shell_started_codex(self):
+        env = self.env.copy()
+        env["SHELL_STARTED_CODEX"] = "1"
+        env["NO_CODEX_SESSION"] = "1"
+        proc_fd_dir = self.tmpdir / "proc" / "101" / "fd"
+        proc_fd_dir.mkdir(parents=True)
+        (proc_fd_dir / "7").symlink_to(self.custom_codex_session_path)
+        env["CODEX_PROC_ROOT"] = str(self.tmpdir / "proc")
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        rows = self.manifest.read_text(encoding="utf-8").splitlines()
+        self.assertIn(
+            "proj\t/tmp/project\tcodex\tresume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
+            rows,
+        )
 
     def test_codex_save_strips_stacked_status_and_memory_prefixes(self):
         env = self.env.copy()
@@ -777,6 +852,17 @@ case "$1" in
     exit 1
     ;;
   list-windows)
+    format=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -F) format="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ "${REQUIRE_REAL_TAB:-0}" = "1" ] && [ "$format" != $'#{window_id}\\t#{window_name}' ]; then
+      printf 'list-windows format does not contain a real tab\\n' >&2
+      exit 64
+    fi
     if [ -n "${TMUX_WINDOWS_OUTPUT:-}" ]; then
       printf '%s\n' "${TMUX_WINDOWS_OUTPUT}"
     fi
@@ -830,6 +916,16 @@ exit 0
         self.assertFalse(
             any(cmd and cmd[0] == "send-keys" for cmd in self.read_tmux_commands()),
             "restore should launch the resume command instead of typing it into a running CLI",
+        )
+
+    def test_codex_restore_requests_tab_delimited_window_fields(self):
+        env = self.env.copy()
+        env["REQUIRE_REAL_TAB"] = "1"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
         )
 
     def test_codex_restore_adds_legacy_codex_resume_last(self):

--- a/tests/test_annotator_status.py
+++ b/tests/test_annotator_status.py
@@ -98,6 +98,62 @@ class AnnotatorStatusTests(unittest.TestCase):
             "READY",
         )
 
+    def test_shell_launched_codex_uses_descendant_prompt_classification(self):
+        pane = self.mod.PaneInfo(
+            pid="%1",
+            current_command="node",
+            start_command="",
+            process_pid="100",
+            dead=False,
+        )
+        self.mod.process_tree_command_context = (
+            lambda process_pid: "codex /usr/local/bin/codex --no-alt-screen"
+        )
+        self.mod.capture_pane_output = lambda pane_id, *, verbose: "work complete\n\u276f\n"
+
+        self.assertEqual(
+            self.mod.classify_pane(pane, self.mod.re.compile(r"node"), verbose=False),
+            "READY",
+        )
+
+    def test_process_tree_context_stays_within_requested_pane_tree(self):
+        class ProcessResult:
+            returncode = 0
+            stdout = (
+                "100 1 bash bash\n"
+                "101 100 node node /usr/local/bin/codex\n"
+                "999 1 node node /usr/local/bin/claude\n"
+            )
+
+        original_run = self.mod.subprocess.run
+        self.mod.subprocess.run = lambda *args, **kwargs: ProcessResult()
+        try:
+            context = self.mod.process_tree_command_context("100")
+        finally:
+            self.mod.subprocess.run = original_run
+
+        self.assertIn("/usr/local/bin/codex", context)
+        self.assertNotIn("/usr/local/bin/claude", context)
+
+    def test_idle_shell_does_not_scan_process_tree_each_poll(self):
+        pane = self.mod.PaneInfo(
+            pid="%1",
+            current_command="bash",
+            start_command="",
+            process_pid="100",
+            dead=False,
+        )
+
+        def unexpected_scan(process_pid):
+            raise AssertionError(f"unexpected process scan for {process_pid}")
+
+        self.mod.process_tree_command_context = unexpected_scan
+
+        self.assertEqual(
+            self.mod.classify_pane(pane, self.mod.re.compile(r"node"), verbose=False),
+            "READY",
+        )
+
     def test_node_launched_claude_uses_prompt_classification(self):
         pane = self.mod.PaneInfo(
             pid="%1",

--- a/tests/test_codex_annotator.py
+++ b/tests/test_codex_annotator.py
@@ -58,6 +58,15 @@ class RunTmuxStub:
 
 
 class AnnotatorWindowTests(unittest.TestCase):
+    def test_window_panes_capture_process_pid_for_descendant_detection(self):
+        annotator = load_annotator_module()
+        annotator.run_tmux = lambda cmd, *, verbose=False: "%1\tnode\t0\t\t123\n"
+
+        panes = annotator.window_pane_states("@1", verbose=False)
+
+        self.assertIsNotNone(panes)
+        self.assertEqual(panes[0].process_pid, "123")
+
     def test_annotates_windows_and_leaves_sessions(self):
         annotator = load_annotator_module()
         stub = RunTmuxStub()

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -127,6 +127,35 @@ class ControlStopTargetTests(unittest.TestCase):
         self.assertEqual([result.stage for result in results], ["interrupt", "terminate"])
 
 
+class ControlRunSelectionTests(unittest.TestCase):
+    def test_stopped_runs_require_include_stopped(self) -> None:
+        tempdir = tempfile.TemporaryDirectory(prefix="control-selection-test-")
+        self.addCleanup(tempdir.cleanup)
+        state_root = Path(tempdir.name)
+        run_dir = state_root / "stopped-run"
+        run_dir.mkdir()
+        (run_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "status": "stopped",
+                    "label": "stopped",
+                    "run_dir": str(run_dir),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(control.ControlError, "no matching looper run"):
+            control.select_control_run(state_root=state_root, label="stopped")
+
+        selected = control.select_control_run(
+            state_root=state_root,
+            label="stopped",
+            include_stopped=True,
+        )
+        self.assertEqual(selected["run_dir"], str(run_dir))
+
+
 class ControlFocusTests(unittest.TestCase):
     def test_append_focus_update_compacts_summary_and_reads_latest(self) -> None:
         tempdir = tempfile.TemporaryDirectory(prefix="control-focus-test-")
@@ -192,6 +221,36 @@ class ControlCliTests(unittest.TestCase):
         self.assertEqual(record["action"], "interrupt_now")
         force_stop.assert_called_once()
         repair.assert_called_once_with(run_dir / "state.json")
+
+    def test_force_stop_repairs_stale_state_before_signaling(self) -> None:
+        tempdir = tempfile.TemporaryDirectory(prefix="control-cli-stale-test-")
+        self.addCleanup(tempdir.cleanup)
+        run_dir = Path(tempdir.name) / "run"
+        run_dir.mkdir()
+        state = {"status": "running", "pid": 100, "run_dir": str(run_dir)}
+        (run_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        output = io.StringIO()
+
+        with (
+            mock.patch.object(cli, "force_stop_from_state", return_value=[]) as force_stop,
+            mock.patch.object(
+                cli,
+                "repair_stale_state_file",
+                return_value=(
+                    {**state, "status": "stopped"},
+                    True,
+                    "supervisor process 100 is no longer running",
+                ),
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            status = cli.control_main(
+                ["stop", "--run-dir", str(run_dir), "--force", "--grace-seconds", "0"]
+            )
+
+        self.assertEqual(status, 0)
+        force_stop.assert_not_called()
+        self.assertIn("repaired stale looper state", output.getvalue())
 
     def test_force_stop_rejects_safe_boundary_flags(self) -> None:
         with self.assertRaises(SystemExit), contextlib.redirect_stderr(io.StringIO()):

--- a/tests/test_control_panel.py
+++ b/tests/test_control_panel.py
@@ -51,7 +51,18 @@ class ControlPanelTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with mock.patch.object(control_panel, "interrupt_from_state", return_value="interrupted"):
+        with (
+            mock.patch.object(
+                control_panel,
+                "repair_stale_state_file",
+                return_value=(
+                    {"status": "running", "pid": 123, "run_dir": str(run_dir)},
+                    False,
+                    None,
+                ),
+            ),
+            mock.patch.object(control_panel, "interrupt_from_state", return_value="interrupted"),
+        ):
             result = control_panel.run_control_pane_action("i", run_dir=run_dir)
 
         self.assertEqual(result.message, "interrupted")

--- a/tests/test_looper.py
+++ b/tests/test_looper.py
@@ -239,8 +239,8 @@ class LooperCoreTests(unittest.TestCase):
                 "workspace-write",
                 "--model",
                 "gpt-5.4",
-                "--effort",
-                "high",
+                "--config",
+                'model_reasoning_effort="high"',
                 "do it",
             ],
         )
@@ -734,6 +734,37 @@ fresh_session_per_loop = "false"
         self.assertTrue(result.timed_out)
         self.assertEqual(result.stop_reason, "local timeout after 0.01 seconds")
         self.assertTrue(transport.closed)
+
+    def test_timeout_cleans_up_descendant_that_inherits_output_pipes(self) -> None:
+        async def exercise() -> tuple[object, float]:
+            child_script = "import time; time.sleep(5)"
+            parent_script = (
+                "import subprocess, sys; "
+                "subprocess.Popen([sys.executable, '-c', " + repr(child_script) + "])"
+            )
+            with tempfile.TemporaryDirectory() as td:
+                started_at = asyncio.get_running_loop().time()
+                result = await asyncio.wait_for(
+                    self.looper.run_command(
+                        command=[sys.executable, "-c", parent_script],
+                        cwd=Path(td),
+                        env={},
+                        timeout_seconds=0.05,
+                        log_path=Path(td) / "run.log",
+                        agent_kind="generic",
+                        patterns=[],
+                        scan_stdout=False,
+                        kill_on_stop_pattern=True,
+                        stream_output=False,
+                    ),
+                    timeout=2,
+                )
+                return result, asyncio.get_running_loop().time() - started_at
+
+        result, elapsed = asyncio.run(exercise())
+
+        self.assertLess(elapsed, 2)
+        self.assertIsNotNone(result.returncode)
 
     def test_run_command_drains_jsonl_line_larger_than_asyncio_default_limit(self) -> None:
         async def exercise() -> tuple[object, str, int]:

--- a/tests/test_status_state.py
+++ b/tests/test_status_state.py
@@ -20,6 +20,16 @@ class StatusStateTest(unittest.TestCase):
             "S",
         )
 
+    def test_parse_linux_proc_start_time_handles_parentheses_in_command_name(self) -> None:
+        fields = ["S", *[str(value) for value in range(1, 19)], "424242"]
+
+        self.assertEqual(
+            status_state._parse_linux_proc_start_time(
+                "123 (cmd with ) paren) " + " ".join(fields)
+            ),
+            "424242",
+        )
+
     def test_active_state_stale_reason_marks_dead_supervisor(self) -> None:
         with mock.patch.object(status_state, "process_is_running", return_value=False):
             reason = status_state.active_state_stale_reason({"status": "running", "pid": 12345})
@@ -31,6 +41,21 @@ class StatusStateTest(unittest.TestCase):
             reason = status_state.active_state_stale_reason({"status": "retrying", "pid": 12345})
 
         self.assertIsNone(reason)
+
+    def test_active_state_stale_reason_rejects_reused_supervisor_pid(self) -> None:
+        with (
+            mock.patch.object(status_state, "process_is_running", return_value=True),
+            mock.patch.object(status_state, "process_identity", return_value="current-token"),
+        ):
+            reason = status_state.active_state_stale_reason(
+                {
+                    "status": "running",
+                    "pid": 12345,
+                    "pid_identity": "original-token",
+                }
+            )
+
+        self.assertEqual(reason, "supervisor process 12345 identity changed")
 
     def test_repair_stale_state_file_records_stopped_state_and_event(self) -> None:
         with mock.patch.object(status_state, "process_is_running", return_value=False):

--- a/tests/test_status_state.py
+++ b/tests/test_status_state.py
@@ -24,9 +24,7 @@ class StatusStateTest(unittest.TestCase):
         fields = ["S", *[str(value) for value in range(1, 19)], "424242"]
 
         self.assertEqual(
-            status_state._parse_linux_proc_start_time(
-                "123 (cmd with ) paren) " + " ".join(fields)
-            ),
+            status_state._parse_linux_proc_start_time("123 (cmd with ) paren) " + " ".join(fields)),
             "424242",
         )
 


### PR DESCRIPTION
## Summary
- preserve exact Codex, Claude, and Gemini session IDs when provider CLIs run under long-lived shell panes
- fix restore window matching, annotator provider detection, unique logs, and Codex effort arguments
- harden looper timeout cleanup and stopped-run force controls against stale or reused PIDs

## Validation
- python3 -m unittest discover -s tests (261 tests)
- ./validate.sh
- ruff check .
- live codex-save: 11 exact IDs, 0 blank commands, 0 fallbacks