### PR TITLE
Add farm doctor and exact session resume integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
         if: matrix.python-version == '3.13'
         run: ./examples/demo.sh
 
+      - name: Run exact session resume integration
+        if: matrix.python-version == '3.13'
+        run: ./tests/integration/session_resume_smoke.sh
+
       - name: Install pinned tmux-deep-history release
         if: matrix.python-version == '3.13'
         run: python integrations/install_tmux_deep_history.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ CODEX_ANNOTATOR_AUTOSTART=0 python3 -m unittest discover -s tests -v
 VALIDATE_SKIP_TMUX=1 ./validate.sh
 ./validate.sh
 ./examples/demo.sh
+./tests/integration/session_resume_smoke.sh
 CODEXFARM_DEEP_HISTORY_BIN=/path/to/tmux-deep-history/bin/tmux-deep-history \
   ./tests/integration/deep_history_smoke.sh
 ```

--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ Saved Codex, Claude, and Gemini windows restore with exact session IDs when `cod
 Only pane 0 is saved. Split layouts and scrollback are not reconstructed. Missing saved directories fall back to `$HOME` with a warning.
 Manifests are written owner-only and via atomic replacement, but they are still trusted executable input because restore launches the recorded commands.
 
+Check installed-helper freshness and manifest resume coverage without printing session IDs:
+
+```bash
+codex-doctor
+CODEX_SESSION=work codex-doctor
+codex-doctor --source /path/to/agent-cli-farm /path/to/manifest.tsv
+```
+
+The doctor exits nonzero for stale or missing installed helpers, malformed or unsafe manifests, blank commands, and provider fallbacks that could resume the wrong conversation.
+
 If tmux sessions are already running (no manifest needed):
 ```bash
 codex-resume            # joins the main Codex session if present
@@ -294,6 +304,7 @@ Tuning and controls:
 - **`codex-status [--session SESSION] [sessions|windows|activity|logs|loopers]`** - Show status information; `loopers --repair-stale-loopers` marks active state files stopped when their supervisor process is gone
 - **`codex-board [create|link|switch] [session]`** - Manage the default or a named board session for navigation
 - **`codex-resume [session] [--board]`** - Attach/switch to an existing Codex/tmux session or named farm board
+- **`codex-doctor [--session NAME] [--source DIR] [manifest]`** - Check installed-helper freshness and manifest resume coverage without displaying session IDs
 - **`codex-save [manifest]`** - Snapshot current windows to a manifest (TSV)
 - **`codex-restore [-a] [-f] [manifest]`** - Restore windows from a manifest
 - **`codex-farm-reboot [--detach] [session]`** - Safely save, stop, restore, and optionally attach to a farm
@@ -430,6 +441,7 @@ Run the basic validation script (requires tmux):
 
 ```bash
 ./validate.sh
+./tests/integration/session_resume_smoke.sh
 CODEXFARM_DEEP_HISTORY_BIN=/path/to/tmux-deep-history/bin/tmux-deep-history \
   ./tests/integration/deep_history_smoke.sh
 ```
@@ -454,6 +466,7 @@ agent-cli-farm/
 │   ├── codex-add      # Add new Codex instances
 │   ├── codex-annotator  # Bash wrapper for annotator
 │   ├── codex-annotator.py # Track tmux window status and READY notifications
+│   ├── codex-doctor   # Diagnose installed-helper and manifest drift
 │   ├── codex-save     # Save manifest of windows
 │   ├── codex-restore  # Restore windows from manifest
 │   ├── codex-farm-reboot # Save, stop, and restore a farm

--- a/bin/codex-doctor
+++ b/bin/codex-doctor
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Diagnose installed-helper drift and restore-manifest session coverage.
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--session NAME] [--source DIR] [manifest-path]
+
+Check the installed Agent CLI Farm helpers and a saved restore manifest.
+Exact provider session IDs are counted but never printed.
+EOF
+}
+
+DEFAULT_SESSION="codexfarm"
+SESSION="${CODEX_SESSION:-$DEFAULT_SESSION}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/codexfarm"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/codexfarm"
+INSTALL_DIR="${CODEXFARM_INSTALL_DIR:-$HOME/bin}"
+SOURCE_DIR="${CODEXFARM_SOURCE_DIR:-}"
+SOURCE_MARKER="$STATE_DIR/install-source"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+issues=0
+
+ok() {
+  printf '[OK] %s\n' "$1"
+}
+
+info() {
+  printf '[INFO] %s\n' "$1"
+}
+
+problem() {
+  printf '[FAIL] %s\n' "$1"
+  issues=$((issues + 1))
+}
+
+warning() {
+  printf '[WARN] %s\n' "$1"
+  issues=$((issues + 1))
+}
+
+safe_name() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'
+}
+
+default_manifest_path_for_session() {
+  local session="$1"
+  if [ "$session" = "$DEFAULT_SESSION" ]; then
+    printf '%s/manifest.tsv' "$CONFIG_DIR"
+  else
+    printf '%s/manifests/%s.tsv' "$CONFIG_DIR" "$(safe_name "$session")"
+  fi
+}
+
+resolve_source_dir() {
+  local candidate="${SOURCE_DIR:-}"
+
+  if [ -z "$candidate" ] && [ -f "$SCRIPT_DIR/../setup.sh" ]; then
+    candidate="$SCRIPT_DIR/.."
+  fi
+  if [ -z "$candidate" ] && [ -r "$SOURCE_MARKER" ]; then
+    IFS= read -r candidate < "$SOURCE_MARKER" || candidate=""
+  fi
+  [ -n "$candidate" ] || return 1
+  [ -d "$candidate/bin" ] && [ -f "$candidate/setup.sh" ] || return 1
+  (cd "$candidate" && pwd)
+}
+
+check_installed_helpers() {
+  local source_dir="$1"
+  local source_file relative installed_file
+  local checked=0
+  local mismatched=0
+  local mismatch_names=""
+
+  if ! command -v cmp >/dev/null 2>&1; then
+    problem "cmp is required to compare installed helpers"
+    return
+  fi
+
+  for source_file in \
+    "$source_dir"/bin/codex-* \
+    "$source_dir"/bin/claude-* \
+    "$source_dir"/bin/gemini-* \
+    "$source_dir"/bin/add_high_memory_warning.sh \
+    "$source_dir"/codex_looper/*.py
+  do
+    [ -f "$source_file" ] || continue
+    case "$source_file" in
+      "$source_dir"/codex_looper/*)
+        relative="codex_looper/${source_file##*/}"
+        ;;
+      *)
+        relative="${source_file##*/}"
+        ;;
+    esac
+    installed_file="$INSTALL_DIR/$relative"
+    checked=$((checked + 1))
+    if [ ! -f "$installed_file" ] || ! cmp -s "$source_file" "$installed_file"; then
+      mismatched=$((mismatched + 1))
+      mismatch_names="${mismatch_names}${mismatch_names:+, }$relative"
+    fi
+  done
+
+  if [ "$checked" -eq 0 ]; then
+    problem "no installable helpers found under $source_dir"
+  elif [ "$mismatched" -gt 0 ]; then
+    problem "$mismatched of $checked installed helpers are missing or stale: $mismatch_names"
+  else
+    ok "all $checked installed helpers match $source_dir"
+  fi
+}
+
+check_manifest() {
+  local manifest="$1"
+  local header=""
+  local stats rows malformed blank exact fallback provider_invalid other
+  local mode=""
+
+  if [ ! -f "$manifest" ]; then
+    problem "manifest not found: $manifest"
+    return
+  fi
+
+  IFS= read -r header < "$manifest" || header=""
+  if [ "$header" != $'name\tdir\tcmd\targs' ]; then
+    problem "malformed manifest header: $manifest"
+    return
+  fi
+
+  if ! command -v awk >/dev/null 2>&1; then
+    problem "awk is required to inspect the manifest"
+    return
+  fi
+
+  if ! stats="$(awk -F '\t' '
+    NR == 1 { next }
+    {
+      rows++
+      if (NF != 4) malformed++
+      cmd = $3
+      args = $4
+      if (cmd == "") {
+        blank++
+      } else if (cmd == "codex") {
+        if (args == "resume --last") fallback++
+        else {
+          session_id = substr(args, 8)
+          if (index(args, "resume ") == 1 && session_id !~ /^--/ && session_id !~ /[[:space:]]/) exact++
+          else provider_invalid++
+        }
+      } else if (cmd == "claude") {
+        if (args == "--continue") fallback++
+        else {
+          session_id = substr(args, 10)
+          if (index(args, "--resume ") == 1 && session_id !~ /^-/ && session_id !~ /[[:space:]]/) exact++
+          else provider_invalid++
+        }
+      } else if (cmd == "gemini") {
+        if (args == "--resume latest") fallback++
+        else {
+          session_id = substr(args, 10)
+          if (index(args, "--resume ") == 1 && session_id !~ /^-/ && session_id !~ /[[:space:]]/) exact++
+          else provider_invalid++
+        }
+      } else {
+        other++
+      }
+    }
+    END {
+      printf "%d\t%d\t%d\t%d\t%d\t%d\t%d\n", \
+        rows + 0, malformed + 0, blank + 0, exact + 0, fallback + 0, \
+        provider_invalid + 0, other + 0
+    }
+  ' "$manifest")"; then
+    problem "unable to inspect manifest rows: $manifest"
+    return
+  fi
+  IFS=$'\t' read -r rows malformed blank exact fallback provider_invalid other <<EOF
+$stats
+EOF
+
+  info "manifest rows: $rows; exact provider sessions: $exact; fallback: $fallback; blank commands: $blank; other commands: $other"
+  if [ "$rows" -eq 0 ]; then
+    warning "manifest contains no saved windows"
+  fi
+  if [ "$malformed" -gt 0 ]; then
+    problem "manifest contains $malformed malformed row(s)"
+  fi
+  if [ "$blank" -gt 0 ]; then
+    problem "manifest contains $blank blank command(s); save again before restoring"
+  fi
+  if [ "$fallback" -gt 0 ]; then
+    warning "manifest contains $fallback provider fallback(s); exact sessions may not restore"
+  fi
+  if [ "$provider_invalid" -gt 0 ]; then
+    problem "manifest contains $provider_invalid provider command(s) with invalid resume arguments"
+  fi
+  if [ "$rows" -gt 0 ] && [ "$malformed" -eq 0 ] && [ "$blank" -eq 0 ] \
+    && [ "$fallback" -eq 0 ] && [ "$provider_invalid" -eq 0 ]; then
+    ok "manifest resume data is healthy"
+  fi
+
+  mode="$(stat -c '%a' "$manifest" 2>/dev/null || stat -f '%Lp' "$manifest" 2>/dev/null || true)"
+  if [ -z "$mode" ]; then
+    warning "unable to determine manifest permissions"
+  elif [ "$mode" != "600" ]; then
+    warning "manifest permissions are $mode; expected 600"
+  else
+    ok "manifest permissions are owner-only (600)"
+  fi
+}
+
+check_runtime() {
+  local window_count
+
+  if ! command -v tmux >/dev/null 2>&1; then
+    problem "tmux is not installed"
+    return
+  fi
+  if tmux has-session -t "$SESSION" 2>/dev/null; then
+    if window_count="$(tmux list-windows -t "$SESSION" -F '#{window_name}' 2>/dev/null \
+      | awk '$0 != "home" { count++ } END { print count + 0 }')"; then
+      ok "tmux session $SESSION is running with $window_count managed window(s)"
+    else
+      warning "unable to list windows in tmux session $SESSION"
+    fi
+  else
+    info "tmux session $SESSION is not currently running"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1 \
+    && systemctl --user is-enabled --quiet codex-autosave.timer >/dev/null 2>&1; then
+    ok "codex autosave timer is enabled"
+  elif [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/codex-autosave.timer" ]; then
+    info "codex autosave timer is installed but not enabled"
+  else
+    info "codex autosave timer is not installed (optional)"
+  fi
+}
+
+session_seen=0
+source_seen=0
+manifest_path=""
+while (( "$#" )); do
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --session)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --session" >&2
+        exit 2
+      fi
+      if [ "$session_seen" -eq 1 ]; then
+        echo "Session specified multiple times" >&2
+        exit 2
+      fi
+      SESSION="$2"
+      session_seen=1
+      shift 2
+      ;;
+    --source)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --source" >&2
+        exit 2
+      fi
+      if [ "$source_seen" -eq 1 ]; then
+        echo "Source specified multiple times" >&2
+        exit 2
+      fi
+      SOURCE_DIR="$2"
+      source_seen=1
+      shift 2
+      ;;
+    --)
+      shift
+      while (( "$#" )); do
+        if [ -n "$manifest_path" ]; then
+          echo "Unexpected argument: $1" >&2
+          exit 2
+        fi
+        manifest_path="$1"
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$manifest_path" ]; then
+        echo "Unexpected argument: $1" >&2
+        exit 2
+      fi
+      manifest_path="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$SESSION" in
+  ""|*[!A-Za-z0-9_.-]*)
+    echo "Invalid session name: $SESSION" >&2
+    exit 2
+    ;;
+esac
+
+manifest_path="${manifest_path:-$(default_manifest_path_for_session "$SESSION")}"
+
+echo "Agent CLI Farm doctor"
+if resolved_source="$(resolve_source_dir)"; then
+  check_installed_helpers "$resolved_source"
+else
+  warning "source checkout unavailable; run setup.sh again or pass --source DIR"
+fi
+check_manifest "$manifest_path"
+check_runtime
+
+if [ "$issues" -eq 0 ]; then
+  echo "Doctor result: healthy"
+  exit 0
+fi
+
+echo "Doctor result: $issues issue(s) found"
+exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -183,7 +183,7 @@ EOF
   require_python
   install_dependencies
 
-  local script_source script_dir shell_name updated_any primary_rc
+  local script_source script_dir shell_name updated_any primary_rc install_source_marker
   script_source="${BASH_SOURCE[0]}"
   script_dir="$(cd "$(dirname "$script_source")" && pwd)"
 
@@ -233,6 +233,12 @@ EOF
     cp -f "$script_dir"/codex_looper/*.py "$HOME/bin/codex_looper/"
     copied+=("codex_looper/")
   fi
+
+  # Remember the checkout used for this install so codex-doctor can detect
+  # copied helpers that have fallen behind their source files.
+  install_source_marker="${XDG_STATE_HOME:-$HOME/.local/state}/codexfarm/install-source"
+  (umask 077; printf '%s\n' "$script_dir" > "$install_source_marker")
+  chmod 600 "$install_source_marker" 2>/dev/null || true
 
   if [ "${#missing[@]}" -gt 0 ]; then
     for wrapper in "${missing[@]}"; do
@@ -307,6 +313,7 @@ EOF
   echo "  codex-add -d /path/project   # Start without attaching"
   echo "  codex-save                   # Snapshot current windows to manifest"
   echo "  codex-farm-reboot            # Save, restart, and restore the default farm"
+  echo "  codex-doctor                 # Check installed helpers and saved resume coverage"
   echo "  codex-restore -a             # Restore windows and attach"
   echo "  codex-resume                 # Attach/switch to existing session"
   echo "  codex-resume work --board    # Jump to the board for the 'work' farm"

--- a/tests/integration/session_resume_smoke.sh
+++ b/tests/integration/session_resume_smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_root="$(mktemp -d)"
+
+cleanup() {
+  set +e
+  if command -v tmux >/dev/null 2>&1; then
+    tmux kill-server >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+home_dir="$tmp_root/home"
+config_dir="$tmp_root/config"
+state_dir="$tmp_root/state"
+private_bin="$tmp_root/bin"
+project_dir="$tmp_root/project"
+tmux_tmp="$tmp_root/tmux"
+mkdir -p "$home_dir" "$config_dir" "$state_dir" "$private_bin" "$project_dir" "$tmux_tmp"
+chmod 700 "$tmux_tmp"
+
+export HOME="$home_dir"
+export XDG_CONFIG_HOME="$config_dir"
+export XDG_STATE_HOME="$state_dir"
+export TMUX_TMPDIR="$tmux_tmp"
+export PATH="$private_bin:$repo_root/bin:$PATH"
+export CODEX_ANNOTATOR_AUTOSTART=0
+export CODEX_AUTOSERVICE_CHOICE=no
+export CODEXFARM_HISTORY_BACKEND=legacy
+export CODEX_LOCK_TITLES=1
+export CODEX_REMAIN_ON_EXIT=0
+export CODEX_TIPS_PROMPT=0
+unset TMUX
+
+session="codexfarm-resume-smoke-$$"
+session_id="019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+session_file="$HOME/.codex/sessions/2026/07/15/rollout-$session_id.jsonl"
+manifest="$config_dir/codexfarm/session-resume.tsv"
+invocation_log="$tmp_root/codex-invocations.log"
+ready_file="$tmp_root/provider-ready"
+mock_codex="$private_bin/codex"
+launcher="$private_bin/provider-launcher"
+
+mkdir -p "$(dirname "$session_file")"
+printf '{"type":"session_meta","payload":{"id":"%s"}}\n' "$session_id" > "$session_file"
+
+cat > "$mock_codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MOCK_CODEX_INVOCATION_LOG"
+exec 9< "$MOCK_CODEX_SESSION_FILE"
+: > "$MOCK_CODEX_READY_FILE"
+trap 'exit 0' TERM INT
+while :; do
+  sleep 1
+done
+EOF
+chmod +x "$mock_codex"
+
+cat > "$launcher" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+"$MOCK_CODEX_BIN" "$@" &
+provider_pid=$!
+cleanup_provider() {
+  kill "$provider_pid" >/dev/null 2>&1 || true
+  wait "$provider_pid" >/dev/null 2>&1 || true
+}
+trap cleanup_provider EXIT HUP INT TERM
+wait "$provider_pid"
+EOF
+chmod +x "$launcher"
+
+export MOCK_CODEX_BIN="$mock_codex"
+export MOCK_CODEX_INVOCATION_LOG="$invocation_log"
+export MOCK_CODEX_READY_FILE="$ready_file"
+export MOCK_CODEX_SESSION_FILE="$session_file"
+
+wait_for_file() {
+  local path="$1"
+  local attempt=0
+  while [ "$attempt" -lt 100 ]; do
+    [ -e "$path" ] && return 0
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  echo "Timed out waiting for $path" >&2
+  return 1
+}
+
+wait_for_invocation() {
+  local expected="$1"
+  local attempt=0
+  while [ "$attempt" -lt 100 ]; do
+    if [ -f "$invocation_log" ] && grep -Fqx "$expected" "$invocation_log"; then
+      return 0
+    fi
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  echo "Timed out waiting for exact restored provider invocation" >&2
+  return 1
+}
+
+echo "=== Exact Session Resume Integration ==="
+
+CODEX_SESSION="$session" \
+  CODEX_NAME="resume-smoke" \
+  CODEX_CMD="$launcher" \
+  "$repo_root/bin/codex-add" -d "$project_dir" >/dev/null
+wait_for_file "$ready_file"
+
+CODEX_SESSION="$session" "$repo_root/bin/codex-save" "$manifest" >/dev/null
+if ! awk -F '\t' -v expected="resume $session_id" '
+  $3 == "codex" && $4 == expected { found = 1 }
+  END { exit(found ? 0 : 1) }
+' "$manifest"; then
+  echo "Save did not discover the exact session through the real pane process tree" >&2
+  exit 1
+fi
+if grep -Fq $'\tcodex\tresume --last' "$manifest"; then
+  echo "Save unexpectedly used the Codex fallback" >&2
+  exit 1
+fi
+echo "[OK] save discovered the exact session from a live provider file descriptor"
+
+tmux kill-session -t "$session"
+: > "$invocation_log"
+rm -f "$ready_file"
+
+CODEX_SESSION="$session" "$repo_root/bin/codex-restore" "$manifest" >/dev/null
+wait_for_file "$ready_file"
+wait_for_invocation "resume $session_id"
+tmux list-windows -t "$session" -F '#{window_name}' | grep -Fqx "resume-smoke"
+echo "[OK] restore launched the provider with the same exact session ID"
+
+echo "=== Exact Session Resume Integration Complete ==="

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCTOR_BIN = REPO_ROOT / "bin" / "codex-doctor"
+SESSION_ID = "019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+class DoctorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="doctor-test-")
+        self.root = Path(self.temp_dir.name)
+        self.home = self.root / "home"
+        self.source = self.root / "source"
+        self.source_bin = self.source / "bin"
+        self.install_bin = self.home / "bin"
+        self.fake_bin = self.root / "fake-bin"
+        self.manifest = self.root / "manifest.tsv"
+        for directory in (self.home, self.source_bin, self.install_bin, self.fake_bin):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        (self.source / "setup.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        for name in ("codex-add", "codex-save", "codex-restore"):
+            make_executable(self.source_bin / name, f"#!/usr/bin/env bash\n# {name}\n")
+            shutil.copy2(self.source_bin / name, self.install_bin / name)
+
+        make_executable(
+            self.fake_bin / "tmux",
+            """#!/usr/bin/env bash
+case "${1:-}" in
+  has-session) exit 0 ;;
+  list-windows) printf 'home\\nproject\\n' ;;
+esac
+""",
+        )
+        make_executable(self.fake_bin / "systemctl", "#!/usr/bin/env bash\nexit 1\n")
+
+        self.manifest.write_text(
+            f"name\tdir\tcmd\targs\nproject\t/tmp/project\tcodex\tresume {SESSION_ID}\n",
+            encoding="utf-8",
+        )
+        self.manifest.chmod(0o600)
+
+        self.env = os.environ.copy()
+        self.env["HOME"] = str(self.home)
+        self.env["XDG_CONFIG_HOME"] = str(self.root / "config")
+        self.env["XDG_STATE_HOME"] = str(self.root / "state")
+        self.env["CODEXFARM_SOURCE_DIR"] = str(self.source)
+        self.env["CODEXFARM_INSTALL_DIR"] = str(self.install_bin)
+        self.env["PATH"] = f"{self.fake_bin}:{self.env.get('PATH', '')}"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_doctor(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [DOCTOR_BIN, "--session", "test", *arguments],
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_healthy_install_and_exact_manifest(self) -> None:
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("all 3 installed helpers match", result.stdout)
+        self.assertIn("exact provider sessions: 1", result.stdout)
+        self.assertIn("fallback: 0", result.stdout)
+        self.assertIn("Doctor result: healthy", result.stdout)
+        self.assertNotIn(SESSION_ID, result.stdout)
+
+    def test_stale_installed_helper_is_actionable(self) -> None:
+        (self.install_bin / "codex-save").write_text("stale\n", encoding="utf-8")
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("1 of 3 installed helpers are missing or stale: codex-save", result.stdout)
+
+    def test_installed_copy_uses_setup_source_marker(self) -> None:
+        installed_doctor = self.install_bin / "codex-doctor"
+        shutil.copy2(DOCTOR_BIN, installed_doctor)
+        source_marker = Path(self.env["XDG_STATE_HOME"]) / "codexfarm" / "install-source"
+        source_marker.parent.mkdir(parents=True)
+        source_marker.write_text(f"{self.source}\n", encoding="utf-8")
+        env = self.env.copy()
+        env.pop("CODEXFARM_SOURCE_DIR")
+
+        result = subprocess.run(
+            [installed_doctor, "--session", "test", self.manifest],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("all 3 installed helpers match", result.stdout)
+
+    def test_blank_and_fallback_manifest_entries_fail_without_printing_ids(self) -> None:
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\n"
+            "blank\t/tmp/blank\t\t\n"
+            "fallback\t/tmp/fallback\tcodex\tresume --last\n",
+            encoding="utf-8",
+        )
+        self.manifest.chmod(0o600)
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("fallback: 1", result.stdout)
+        self.assertIn("blank commands: 1", result.stdout)
+        self.assertIn("save again before restoring", result.stdout)
+
+    def test_malformed_header_fails_cleanly(self) -> None:
+        self.manifest.write_text("not-a-manifest\n", encoding="utf-8")
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("malformed manifest header", result.stdout)
+
+    def test_option_like_resume_value_is_not_counted_as_an_exact_session(self) -> None:
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\nproject\t/tmp/project\tcodex\tresume --dangerous\n",
+            encoding="utf-8",
+        )
+        self.manifest.chmod(0o600)
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("exact provider sessions: 0", result.stdout)
+        self.assertIn("provider command(s) with invalid resume arguments", result.stdout)
+
+    def test_rejects_duplicate_session_arguments(self) -> None:
+        result = subprocess.run(
+            [DOCTOR_BIN, "--session", "one", "--session", "two", self.manifest],
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Session specified multiple times", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -134,8 +134,12 @@ exit 98
         self.assertFalse(self.pkg_log.exists(), "package manager should not be called")
         self.assertTrue((Path(self.env["HOME"]) / "bin" / "codex-add").exists())
         self.assertTrue((Path(self.env["HOME"]) / "bin" / "codex-looper").exists())
+        self.assertTrue((Path(self.env["HOME"]) / "bin" / "codex-doctor").exists())
         self.assertTrue((Path(self.env["HOME"]) / "bin" / "codex-memoryflag").exists())
         self.assertTrue((Path(self.env["HOME"]) / "bin" / "add_high_memory_warning.sh").exists())
+        source_marker = Path(self.env["XDG_STATE_HOME"]) / "codexfarm" / "install-source"
+        self.assertEqual(source_marker.read_text(encoding="utf-8").strip(), str(REPO_ROOT))
+        self.assertEqual(stat.S_IMODE(source_marker.stat().st_mode), 0o600)
 
     def test_installs_claude_and_gemini_wrappers(self) -> None:
         make_executable(self.bin_dir / "tmux", "#!/usr/bin/env bash\nexit 0\n")

--- a/validate.sh
+++ b/validate.sh
@@ -110,6 +110,7 @@ check_static_behavior() {
     require_output "codex-add help" "Usage:" "$repo_root/bin/codex-add" --help
     require_output "codex-board help" "Usage:" "$repo_root/bin/codex-board" --help
     require_output "codex-farm-reboot help" "Usage:" "$repo_root/bin/codex-farm-reboot" --help
+    require_output "codex-doctor help" "Usage:" "$repo_root/bin/codex-doctor" --help
     require_output "codex-status help" "Usage:" "$repo_root/bin/codex-status" --help
     require_output "codex-looper help" "Tiny coding-agent looper" "$repo_root/bin/codex-looper" --help
     require_output "codex-watch help" "Usage:" "$repo_root/bin/codex-watch" --help


### PR DESCRIPTION
## What changed

- add `codex-doctor` to detect stale installed helpers, malformed or weak manifests, blank commands, provider fallbacks, and unsafe manifest permissions without printing session IDs
- record the setup source checkout with owner-only permissions so installed copies can be compared against the current source
- add isolated real-tmux coverage for shell-to-provider process-tree discovery and exact save/restore invocation
- wire the new command and integration check into setup, validation, CI, and documentation

## Why

The exact-session fix could be present in the repository while copied commands and the active manifest remained stale. Existing unit stubs covered parsing but did not prove the complete procfs/tmux lifecycle. These changes make that operational drift visible and exercise the original failure mode end to end.

## Validation

- 268 unit tests
- Ruff format and lint
- Bash syntax and ShellCheck
- `./validate.sh`
- `./examples/demo.sh`
- `./tests/integration/session_resume_smoke.sh`
- pinned deep-history integration