### PR TITLE
Test deep history through the farm teardown path

### DIFF
--- a/tests/integration/deep_history_smoke.sh
+++ b/tests/integration/deep_history_smoke.sh
@@ -88,7 +88,12 @@ assert metadata["mirror_bytes"] > 0, metadata
 assert pathlib.Path(sys.argv[2]).stat().st_mode & 0o777 == 0o600
 PY
 
-"$DEEP_HISTORY_BIN" stop -t "$PANE_ID"
+# Exercise the teardown path Agent CLI Farm actually uses. The pinned plugin's
+# standalone `stop` command and logger both update metadata, so a fast logger
+# exit can be overwritten from `closed` back to `closing`. Farm reboot instead
+# destroys managed windows/sessions, which closes tmux's pipe without that
+# competing writer.
+tmux kill-window -t "$SESSION:1"
 CLOSED=0
 for _ in $(seq 1 200); do
     if grep -q '"status": "closed"' "$RUN_DIR/metadata.json" 2>/dev/null; then


### PR DESCRIPTION
## What changed

The deep-history integration now tears down the managed farm window with tmux, matching `codex-farm-reboot`, while continuing to require the logger metadata to reach `status: closed`.

## Root cause

The pinned plugin's standalone `stop` command and its logger are competing metadata writers. When the logger exits quickly, the stop service can overwrite the logger's terminal `closed` record back to `closing`, leaving a false timeout even though the logger has exited. Agent CLI Farm does not use that standalone stop path during reboot; it destroys the managed window/session.

## Validation

- Bash syntax
- ShellCheck
- 40 concurrent deep-history integration stress runs, all passing