### PR TITLE
Fix automatic deep history scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ backward compatibility.
 ## Features
 
 - **Automated session management**: Long-lived tmux session that persists across reboots
-- **Durable pane history**: Optional tmux-deep-history integration adds rotated raw/normalized transcripts while preserving timestamped farm logs
+- **Durable pane history**: Optional tmux-deep-history integration adds rotated raw/normalized transcripts, a seamless Page Up handoff beyond tmux's in-memory buffer, and compatible timestamped farm logs
 - **Unified monitoring**: Watch all agent instances from a single consolidated view
 - **Fast navigation**: Optional "board" session for quick switching between instances
 - **Snapshot/restore**: Save a manifest of windows and restore them later
@@ -53,6 +53,13 @@ This will:
 If `tmux` is unavailable, core tmux commands will not work until you install it. If `multitail` is unavailable, `codex-watch` falls back to a simpler `tail` view.
 Omit `--with-deep-history` when you want the legacy flat-log backend only. Re-running the setup
 command is safe; the installed version can change only when this repository's reviewed lock changes.
+
+Deep history is intentionally opt-in because terminal transcripts can contain commands, private
+paths, credentials, and other sensitive output. Once installed, the default `auto` backend starts
+recording current tmux panes and enables the plugin's global tmux hooks for panes created afterward.
+Set `CODEXFARM_HISTORY_BACKEND=legacy` when launching a pane to turn those hooks off and use only
+the flat compatibility log. If the plugin is absent, `codex-add` reports the legacy fallback
+instead of silently making deep history look active.
 
 ### 2. Add Codex, Claude, or Gemini Instances
 
@@ -179,6 +186,8 @@ Notes:
 - Force full mode: `codex-watch --mode multitail`.
 - With the installed deep-history backend, one `pipe-pane` owner writes durable segmented history and mirrors the live raw stream into the same flat logs used by `codex-watch`.
 - Flat compatibility logs contain output emitted after the pane pipe is enabled. Deep history separately captures scrollback already visible when recording starts.
+- Deep history is not a literal extension of tmux's internal grid. Use `Prefix + [` for recent copy-mode history; when Page Up reaches the absolute top, the farm's default seamless handoff opens the older disk transcript in a popup. `Prefix + H` opens the full Deep History menu, and `Alt-u` opens older history directly from copy mode. Mouse-wheel scrolling remains inside tmux's native buffer and does not cross the disk-history boundary.
+- Plugin installation raises tmux's global history limit from its usual 2,000 rows to 50,000 for panes created afterward. Existing panes keep their original in-memory limit, but `codex-add` backfills deep-history recording for existing tmux panes unless another output pipe already owns one. Recreate panes (or save and reboot the farm) only when you also want the larger in-memory limit.
 - `codex-watch` discovers log files once at startup. Restart it to include newly-created logs.
 - Multi-file tail output keeps source labels so interleaved lines can still be traced to a window log.
 - First run shows an optional tmux tips prompt; choose Yes to see basics. Answer "Don't show again" to persist your preference. Re-enable temporarily with `CODEX_TIPS_PROMPT=1` or permanently by removing `~/.local/state/codexfarm/no_tips`.
@@ -336,6 +345,8 @@ Common:
 - **`CODEXFARM_WITH_DEEP_HISTORY`** - set to `1` as an alternative to `setup.sh --with-deep-history`
 - **`CODEXFARM_HISTORY_BACKEND`** - `auto` (default), `legacy`, or `deep-history`; auto uses the pinned plugin when installed and otherwise preserves legacy logging
 - **`CODEXFARM_DEEP_HISTORY_BIN`** - override the deep-history executable discovered under the XDG data directory
+- **`CODEXFARM_DEEP_HISTORY_PYTHON_BIN`** - override the Python 3.10+ interpreter used by deep-history hooks and loggers (default searches supported `python3` and versioned commands)
+- **`CODEXFARM_DEEP_HISTORY_SEAMLESS_PAGEUP`** - set to `0` to keep tmux's ordinary Page Up behavior at the top of copy mode instead of opening the older disk transcript (default `1`)
 - **`CODEX_LOOPER_LAYOUT`** - looper tmux layout: `auto`, `single`, or `split`; farm launches default to `split`
 
 Annotator-specific:

--- a/bin/codex-add
+++ b/bin/codex-add
@@ -137,6 +137,33 @@ resolve_executable() {
   esac
 }
 
+python_is_supported() {
+  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
+    >/dev/null 2>&1
+}
+
+resolve_deep_history_python() {
+  local candidate resolved
+  for candidate in \
+    "${CODEXFARM_DEEP_HISTORY_PYTHON_BIN:-}" \
+    "${TMUX_DEEP_HISTORY_PYTHON:-}" \
+    "${CODEXFARM_PYTHON_BIN:-}" \
+    python3.14 \
+    python3.13 \
+    python3.12 \
+    python3.11 \
+    python3.10 \
+    python3
+  do
+    [ -n "$candidate" ] || continue
+    if resolved="$(resolve_executable "$candidate")" && python_is_supported "$resolved"; then
+      printf '%s\n' "$resolved"
+      return 0
+    fi
+  done
+  return 1
+}
+
 detach=0
 dir_arg=
 session_arg=
@@ -234,6 +261,8 @@ LOGDIR="$STATE_DIR/logs"
 DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 HISTORY_BACKEND="${CODEXFARM_HISTORY_BACKEND:-auto}"
 DEEP_HISTORY_BIN="${CODEXFARM_DEEP_HISTORY_BIN:-$DATA_HOME/codexfarm/plugins/tmux-deep-history/bin/tmux-deep-history}"
+DEEP_HISTORY_PYTHON_BIN=""
+DEEP_HISTORY_SEAMLESS_PAGEUP="${CODEXFARM_DEEP_HISTORY_SEAMLESS_PAGEUP:-on}"
 SELECTED_HISTORY_BACKEND="legacy"
 ANNOTATOR_BIN="$(get_env ANNOTATOR_BIN "$(dirname "$0")/codex-annotator")"
 CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -258,6 +287,18 @@ case "$HISTORY_BACKEND" in
   auto|legacy|deep-history) ;;
   *)
     echo "Invalid CODEXFARM_HISTORY_BACKEND: $HISTORY_BACKEND" >&2
+    exit 2
+    ;;
+esac
+case "$DEEP_HISTORY_SEAMLESS_PAGEUP" in
+  1|true|TRUE|True|yes|YES|Yes|on|ON|On)
+    DEEP_HISTORY_SEAMLESS_PAGEUP=on
+    ;;
+  0|false|FALSE|False|no|NO|No|off|OFF|Off)
+    DEEP_HISTORY_SEAMLESS_PAGEUP=off
+    ;;
+  *)
+    echo "Invalid CODEXFARM_DEEP_HISTORY_SEAMLESS_PAGEUP: $DEEP_HISTORY_SEAMLESS_PAGEUP" >&2
     exit 2
     ;;
 esac
@@ -489,30 +530,58 @@ start_status_annotator() {
 }
 
 configure_history_backend() {
-  local resolved_bin deep_root installed_root install_error
+  local resolved_bin resolved_python deep_root installed_root install_error
+  local desired_integration installed_integration table
   SELECTED_HISTORY_BACKEND="legacy"
-  [ "$HISTORY_BACKEND" != "legacy" ] || return 0
+  if [ "$HISTORY_BACKEND" = "legacy" ]; then
+    # The plugin's hooks are global. Explicit legacy mode must disable them
+    # before creating the pane or they can claim tmux's single output pipe.
+    tmux set-option -gq '@deep-history-auto-start' off >/dev/null 2>&1 || true
+    return 0
+  fi
 
   if ! resolved_bin="$(resolve_executable "$DEEP_HISTORY_BIN")"; then
     if [ "$HISTORY_BACKEND" = "deep-history" ]; then
       echo "warning: tmux-deep-history is unavailable; using legacy pane logging" >&2
+    else
+      echo "warning: tmux-deep-history is not installed; using legacy pane logging" >&2
+      echo "warning: rerun setup.sh --with-deep-history, or set CODEXFARM_HISTORY_BACKEND=legacy to opt out" >&2
     fi
     return 0
   fi
 
   DEEP_HISTORY_BIN="$resolved_bin"
-  if ! tmux set-option -gq '@deep-history-auto-start' off; then
-    echo "warning: unable to disable deep-history auto-start; using legacy pane logging" >&2
+  if ! resolved_python="$(resolve_deep_history_python)"; then
+    echo "warning: tmux-deep-history requires Python 3.10 or newer; using legacy pane logging" >&2
+    return 0
+  fi
+  DEEP_HISTORY_PYTHON_BIN="$resolved_python"
+  if ! tmux set-option -gq '@deep-history-auto-start' off \
+    || ! tmux set-option -gq '@deep-history-seamless-pageup' "$DEEP_HISTORY_SEAMLESS_PAGEUP" \
+    || ! tmux set-environment -g TMUX_DEEP_HISTORY_PYTHON "$DEEP_HISTORY_PYTHON_BIN" \
+    || ! tmux set-environment -t "$SESSION" TMUX_DEEP_HISTORY_PYTHON "$DEEP_HISTORY_PYTHON_BIN"; then
+    echo "warning: unable to configure tmux-deep-history; using legacy pane logging" >&2
     return 0
   fi
   deep_root="$(cd "$(dirname "$DEEP_HISTORY_BIN")/.." && pwd)"
   installed_root="$(tmux show-options -gqv '@deep-history-root' 2>/dev/null || true)"
-  if [ "$installed_root" != "$deep_root" ]; then
-    if ! install_error=$("$DEEP_HISTORY_BIN" install 2>&1); then
+  # Bump this marker whenever farm-managed plugin bindings/options change.
+  desired_integration="2:$DEEP_HISTORY_SEAMLESS_PAGEUP"
+  installed_integration="$(tmux show-options -gqv '@codexfarm-deep-history-integration' 2>/dev/null || true)"
+  if [ "$installed_root" != "$deep_root" ] || [ "$installed_integration" != "$desired_integration" ]; then
+    if ! install_error=$(TMUX_DEEP_HISTORY_PYTHON="$DEEP_HISTORY_PYTHON_BIN" \
+      "$DEEP_HISTORY_BIN" install 2>&1); then
       echo "warning: unable to initialize tmux-deep-history; using legacy pane logging" >&2
       [ -z "$install_error" ] || printf '%s\n' "$install_error" >&2
       return 0
     fi
+    if [ "$DEEP_HISTORY_SEAMLESS_PAGEUP" = "off" ]; then
+      for table in copy-mode copy-mode-vi; do
+        tmux bind-key -T "$table" PPage send-keys -X page-up >/dev/null 2>&1 || true
+      done
+    fi
+    tmux set-option -gq '@codexfarm-deep-history-integration' "$desired_integration" \
+      >/dev/null 2>&1 || true
   fi
   SELECTED_HISTORY_BACKEND="deep-history"
 }
@@ -533,7 +602,8 @@ attach_history_logging() {
   local start_error
   if [ "$SELECTED_HISTORY_BACKEND" = "deep-history" ]; then
     if start_error=$(
-      "$DEEP_HISTORY_BIN" start -t "$SESSION:$WIN" --mirror-output "$LOGFILE" 2>&1
+      TMUX_DEEP_HISTORY_PYTHON="$DEEP_HISTORY_PYTHON_BIN" \
+        "$DEEP_HISTORY_BIN" start -t "$SESSION:$WIN" --mirror-output "$LOGFILE" 2>&1
     ); then
       return 0
     fi
@@ -542,6 +612,26 @@ attach_history_logging() {
     SELECTED_HISTORY_BACKEND="legacy"
   fi
   attach_legacy_log_pipe
+}
+
+enable_history_auto_start() {
+  local pane_states
+  [ "$SELECTED_HISTORY_BACKEND" = "deep-history" ] || return 0
+  if ! tmux set-option -gq '@deep-history-auto-start' on; then
+    echo "warning: unable to enable automatic deep-history recording" >&2
+    return 0
+  fi
+  pane_states="$(tmux list-panes -a -F '#{pane_pipe}:#{@deep-history-owned}' 2>/dev/null || true)"
+  if ! printf '%s\n' "$pane_states" | grep -q '^0:'; then
+    return 0
+  fi
+  # The plugin's hooks are global, so bring every existing tmux pane under the
+  # same policy too. This can be slow with many panes, so do it asynchronously;
+  # an existing foreign pipe is reported and left untouched.
+  (
+    TMUX_DEEP_HISTORY_PYTHON="$DEEP_HISTORY_PYTHON_BIN" \
+      "$DEEP_HISTORY_BIN" start-all >/dev/null 2>&1 || true
+  ) &
 }
 
 remain_on_exit_enabled() {
@@ -598,7 +688,12 @@ if remain_on_exit_enabled; then
   WINDOW_CMDLINE="tmux set-window-option -q remain-on-exit on >/dev/null 2>&1 || true; exec $CMDLINE"
 fi
 
-WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" "$WINDOW_CMDLINE")
+if [ "$SELECTED_HISTORY_BACKEND" = "deep-history" ]; then
+  WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" \
+    -e "TMUX_DEEP_HISTORY_PYTHON=$DEEP_HISTORY_PYTHON_BIN" "$WINDOW_CMDLINE")
+else
+  WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" "$WINDOW_CMDLINE")
+fi
 
 if remain_on_exit_enabled; then
   tmux set-window-option -t "$SESSION:$WIN" remain-on-exit on >/dev/null 2>&1 || true
@@ -616,6 +711,7 @@ fi
 # Attach exactly one pane pipe. Deep history owns it when available and mirrors
 # its raw stream to LOGFILE so codex-watch remains backward compatible.
 attach_history_logging
+enable_history_auto_start
 
 # Link to board session if it exists
 tmux has-session -t "$BOARD_SESSION" 2>/dev/null && tmux link-window -s "$SESSION:$WIN" -t "$BOARD_SESSION"

--- a/codex_looper/hybrid.py
+++ b/codex_looper/hybrid.py
@@ -162,9 +162,7 @@ def extract_session_id_from_codex_session(path: Path, *, max_lines: int = 50) ->
     return None
 
 
-def _codex_session_metadata(
-    path: Path, *, max_lines: int = 20
-) -> tuple[float | None, Path | None]:
+def _codex_session_metadata(path: Path, *, max_lines: int = 20) -> tuple[float | None, Path | None]:
     """Read the session start time and cwd without trusting the file mtime."""
     try:
         with path.open("r", encoding="utf-8", errors="replace") as handle:
@@ -185,7 +183,7 @@ def _codex_session_metadata(
 
                 raw_started_at = payload.get("timestamp") or data.get("timestamp")
                 started_at = None
-                if isinstance(raw_started_at, (int, float)):
+                if isinstance(raw_started_at, int | float):
                     started_at = float(raw_started_at)
                 elif isinstance(raw_started_at, str) and raw_started_at:
                     try:

--- a/integrations/install_tmux_deep_history.py
+++ b/integrations/install_tmux_deep_history.py
@@ -17,6 +17,7 @@ import zipfile
 from pathlib import Path, PurePosixPath
 
 PROJECT_NAME = "tmux-deep-history"
+LAUNCHER_NAME = "tmux_deep_history_launcher.sh"
 LOCK_KEYS = {"repository", "version", "sha256"}
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:[-+][A-Za-z0-9.-]+)?$")
@@ -123,7 +124,11 @@ def extract_release(archive_path: Path, destination: Path) -> Path:
 
 
 def install_release(
-    *, lock_path: Path, destination: Path, archive_path: Path | None = None
+    *,
+    lock_path: Path,
+    destination: Path,
+    archive_path: Path | None = None,
+    launcher_path: Path | None = None,
 ) -> tuple[Path, str]:
     lock = read_lock(lock_path)
     destination = Path(os.path.abspath(os.fspath(destination.expanduser())))
@@ -169,6 +174,20 @@ def install_release(
         if not os.access(required[1], os.X_OK):
             raise InstallError("release CLI entrypoint is not executable")
 
+        launcher = launcher_path or Path(__file__).resolve().with_name(LAUNCHER_NAME)
+        if not launcher.is_file():
+            raise InstallError(f"deep-history compatibility launcher is missing: {launcher}")
+        upstream_cli = required[1].with_name(f"{PROJECT_NAME}-upstream")
+        try:
+            os.replace(required[1], upstream_cli)
+            shutil.copyfile(launcher, required[1])
+            required[1].chmod(0o755)
+            configured_python = required[1].with_name(".codexfarm-python")
+            configured_python.write_text(f"{Path(sys.executable).resolve()}\n", encoding="utf-8")
+            configured_python.chmod(0o600)
+        except OSError as exc:
+            raise InstallError(f"unable to install deep-history compatibility launcher: {exc}") from exc
+
         backup = work_dir / "previous-install"
         had_previous = destination.exists() or destination.is_symlink()
         if had_previous:
@@ -198,7 +217,9 @@ def main() -> int:
     args = parse_args()
     try:
         destination, version = install_release(
-            lock_path=args.lock_file, destination=args.destination, archive_path=args.archive
+            lock_path=args.lock_file,
+            destination=args.destination,
+            archive_path=args.archive,
         )
     except InstallError as exc:
         print(f"tmux-deep-history installation failed: {exc}", file=sys.stderr)

--- a/integrations/install_tmux_deep_history.py
+++ b/integrations/install_tmux_deep_history.py
@@ -186,7 +186,9 @@ def install_release(
             configured_python.write_text(f"{Path(sys.executable).resolve()}\n", encoding="utf-8")
             configured_python.chmod(0o600)
         except OSError as exc:
-            raise InstallError(f"unable to install deep-history compatibility launcher: {exc}") from exc
+            raise InstallError(
+                f"unable to install deep-history compatibility launcher: {exc}"
+            ) from exc
 
         backup = work_dir / "previous-install"
         had_previous = destination.exists() or destination.is_symlink()

--- a/integrations/tmux_deep_history_launcher.sh
+++ b/integrations/tmux_deep_history_launcher.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+launcher_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="$(cd -- "$launcher_dir/.." && pwd)"
+configured_python=""
+if [[ -r "$launcher_dir/.codexfarm-python" ]]; then
+    IFS= read -r configured_python < "$launcher_dir/.codexfarm-python" || configured_python=""
+fi
+
+resolve_executable() {
+    local candidate="$1"
+    case "$candidate" in
+        */*) [[ -x "$candidate" ]] && printf '%s\n' "$candidate" ;;
+        *) command -v "$candidate" 2>/dev/null ;;
+    esac
+}
+
+resolved=""
+for candidate in \
+    "${CODEXFARM_DEEP_HISTORY_PYTHON_BIN:-}" \
+    "${TMUX_DEEP_HISTORY_PYTHON:-}" \
+    "${CODEXFARM_PYTHON_BIN:-}" \
+    "$configured_python" \
+    python3.14 \
+    python3.13 \
+    python3.12 \
+    python3.11 \
+    python3.10 \
+    python3
+do
+    [[ -n "$candidate" ]] || continue
+    if resolved_candidate="$(resolve_executable "$candidate")"; then
+        resolved="$resolved_candidate"
+        break
+    fi
+done
+
+if [[ -z "$resolved" ]]; then
+    printf '%s\n' 'tmux-deep-history requires Python 3.10 or newer' >&2
+    exit 1
+fi
+
+export TMUX_DEEP_HISTORY_PYTHON="$resolved"
+export TMUX_DEEP_HISTORY_ROOT="$plugin_root"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    export PYTHONPATH="$plugin_root/src:$PYTHONPATH"
+else
+    export PYTHONPATH="$plugin_root/src"
+fi
+
+# Validate and enter the module in one interpreter process. The upstream
+# launcher performs a separate version probe first, which can exceed the
+# logger's 1.5-second readiness deadline on macOS when repeated through this
+# compatibility layer.
+exec "$resolved" -c '
+import runpy
+import shlex
+import sys
+import time
+
+if sys.version_info < (3, 10):
+    print("tmux-deep-history requires Python 3.10 or newer", file=sys.stderr)
+    raise SystemExit(1)
+
+# tmux may return from pipe-pane just before #{pane_pipe} reflects the new
+# consumer. Upstream 0.1.0 checks immediately and can tear down a healthy
+# logger during that small window, so make start_pipe wait for visibility.
+from tmux_deep_history.tmux import PaneInfo
+from tmux_deep_history.tmux import Tmux
+from tmux_deep_history.tmux import TmuxError
+
+_start_pipe = Tmux.start_pipe
+
+
+def _show_global_option_batched(self, name, default=""):
+    options = getattr(self, "_codexfarm_global_options", None)
+    if options is None:
+        options = {}
+        completed = self.run("show-options", "-g", check=False)
+        if completed.returncode == 0:
+            for line in str(completed.stdout).splitlines():
+                option_name, separator, encoded_value = line.partition(" ")
+                if not separator or not option_name.startswith("@"):
+                    continue
+                try:
+                    decoded = shlex.split(encoded_value, comments=False)
+                    value = decoded[0] if len(decoded) == 1 else encoded_value
+                except ValueError:
+                    value = encoded_value
+                options[option_name] = value
+        self._codexfarm_global_options = options
+    value = options.get(name, "")
+    return value if value != "" else default
+
+
+def _pane_info_batched(self, target):
+    field_names = (
+        "pane_id",
+        "session_id",
+        "session_name",
+        "window_id",
+        "window_index",
+        "window_name",
+        "pane_index",
+        "pane_pid",
+        "pane_current_command",
+        "pane_current_path",
+        "pane_title",
+        "history_size",
+        "history_limit",
+        "history_bytes",
+        "pane_pipe",
+        "pane_height",
+    )
+    delimiter = "|codexfarm:field|"
+    values = self.display(
+        delimiter.join(f"#{{{field}}}" for field in field_names),
+        target,
+    ).split(delimiter)
+    if len(values) != len(field_names) or not values[0].startswith("%"):
+        target_label = target if target else "<current>"
+        raise TmuxError(
+            [self.binary, "display-message"],
+            f"unable to resolve pane target: {target_label}",
+        )
+
+    def number(index):
+        try:
+            return int(values[index] or 0)
+        except ValueError:
+            return 0
+
+    return PaneInfo(
+        pane_id=values[0],
+        session_id=values[1],
+        session_name=values[2],
+        window_id=values[3],
+        window_index=values[4],
+        window_name=values[5],
+        pane_index=values[6],
+        pane_pid=values[7],
+        current_command=values[8],
+        current_path=values[9],
+        title=values[10],
+        history_size=number(11),
+        history_limit=number(12),
+        history_bytes=number(13),
+        pane_pipe=values[14] == "1",
+        pane_height=number(15),
+    )
+
+
+def _server_identity_batched(self):
+    delimiter = "|codexfarm:field|"
+    values = self.display(
+        f"#{{pid}}{delimiter}#{{start_time}}{delimiter}#{{socket_path}}"
+    ).split(delimiter)
+    if len(values) != 3:
+        return "", "", ""
+    return values[0], values[1], values[2]
+
+
+def _start_pipe_after_tmux_settles(self, target, command, *, only_if_none=True):
+    # A pane id beginning with %0 is consumed by tmux shell-command formatting
+    # expansion unless the percent sign is doubled before pipe-pane receives it.
+    command = command.replace(" --pane-id %", " --pane-id %%", 1)
+    _start_pipe(self, target, command, only_if_none=only_if_none)
+    deadline = time.monotonic() + 0.75
+    while time.monotonic() < deadline:
+        if self.display("#{pane_pipe}", target, check=False) == "1":
+            return
+        time.sleep(0.025)
+
+
+Tmux.show_global_option = _show_global_option_batched
+Tmux.pane_info = _pane_info_batched
+Tmux.server_identity = _server_identity_batched
+Tmux.start_pipe = _start_pipe_after_tmux_settles
+sys.argv[0] = "tmux-deep-history"
+runpy.run_module("tmux_deep_history.cli", run_name="__main__")
+' "$@"

--- a/integrations/tmux_deep_history_launcher.sh
+++ b/integrations/tmux_deep_history_launcher.sh
@@ -58,6 +58,7 @@ import runpy
 import shlex
 import sys
 import time
+from pathlib import Path
 
 if sys.version_info < (3, 10):
     print("tmux-deep-history requires Python 3.10 or newer", file=sys.stderr)
@@ -165,10 +166,24 @@ def _start_pipe_after_tmux_settles(self, target, command, *, only_if_none=True):
     # A pane id beginning with %0 is consumed by tmux shell-command formatting
     # expansion unless the percent sign is doubled before pipe-pane receives it.
     command = command.replace(" --pane-id %", " --pane-id %%", 1)
+    run_dir = None
+    try:
+        command_arguments = shlex.split(command)
+        run_dir_index = command_arguments.index("--run-dir") + 1
+        run_dir = Path(command_arguments[run_dir_index])
+    except (ValueError, IndexError):
+        pass
     _start_pipe(self, target, command, only_if_none=only_if_none)
-    deadline = time.monotonic() + 0.75
+    pipe_visible = False
+    deadline = time.monotonic() + (5.0 if run_dir is not None else 0.75)
     while time.monotonic() < deadline:
+        if run_dir is not None and (run_dir / "logger.ready").is_file():
+            return
         if self.display("#{pane_pipe}", target, check=False) == "1":
+            pipe_visible = True
+            if run_dir is None:
+                return
+        elif pipe_visible:
             return
         time.sleep(0.025)
 

--- a/setup.sh
+++ b/setup.sh
@@ -275,8 +275,12 @@ EOF
     fi
     echo ""
     echo "Installing pinned tmux-deep-history integration..."
-    "$setup_python" "$script_dir/integrations/install_tmux_deep_history.py" \
-      "${deep_history_installer_args[@]}"
+    if [ "${#deep_history_installer_args[@]}" -gt 0 ]; then
+      "$setup_python" "$script_dir/integrations/install_tmux_deep_history.py" \
+        "${deep_history_installer_args[@]}"
+    else
+      "$setup_python" "$script_dir/integrations/install_tmux_deep_history.py"
+    fi
   fi
 
   echo ""
@@ -346,7 +350,7 @@ if [ -n "${BASH_SOURCE:-}" ] && [ "${BASH_SOURCE[0]:-}" != "$0" ]; then
 fi
 
 if [ "$codexfarm_setup_is_sourced" -eq 1 ]; then
-  CODEXFARM_SETUP_SOURCED=1 codexfarm_setup_main
+  CODEXFARM_SETUP_SOURCED=1 codexfarm_setup_main "$@"
   case ":$PATH:" in
     *:"$HOME/bin":*) ;;
     *) export PATH="$HOME/bin:$PATH" ;;

--- a/tests/integration/deep_history_smoke.sh
+++ b/tests/integration/deep_history_smoke.sh
@@ -20,6 +20,16 @@ SESSION="codexfarm-deep-history-$$"
 
 cleanup() {
     tmux kill-server >/dev/null 2>&1 || true
+    # Logger shutdown writes final metadata before removing logger.ready. Wait
+    # for those writers so recursive cleanup cannot race a recreated state dir.
+    for _ in $(seq 1 100); do
+        if [[ ! -d "$TEMP_DIR" ]] \
+            || ! find "$TEMP_DIR" -type f -name logger.ready -print -quit 2>/dev/null \
+                | grep -q .; then
+            break
+        fi
+        sleep 0.05
+    done
     rm -rf "$TEMP_DIR"
 }
 trap cleanup EXIT INT TERM HUP

--- a/tests/integration/deep_history_smoke.sh
+++ b/tests/integration/deep_history_smoke.sh
@@ -13,7 +13,9 @@ if [[ ! -x "$DEEP_HISTORY_BIN" ]]; then
     exit 1
 fi
 
-TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codexfarm-deep-history-test.XXXXXX")"
+# tmux Unix-domain socket paths are short (roughly 100 bytes on macOS). The
+# platform TMPDIR can already consume most of that budget before our suffix.
+TEMP_DIR="$(mktemp -d "/tmp/codexfarm-dh.XXXXXX")"
 SESSION="codexfarm-deep-history-$$"
 
 cleanup() {
@@ -54,9 +56,42 @@ OUTPUT="$("$ROOT_DIR/bin/codex-add" -d "$TEMP_DIR/project")"
 grep -q 'History backend: deep-history' <<< "$OUTPUT"
 
 PANE_ID="$(tmux display-message -p -t "$SESSION:1" '#{pane_id}')"
+HOME_PANE_ID="$(tmux display-message -p -t "$SESSION:0" '#{pane_id}')"
 [[ "$(tmux display-message -p -t "$PANE_ID" '#{pane_pipe}')" == "1" ]]
 [[ "$(tmux show-options -pqv -t "$PANE_ID" '@deep-history-owned')" == "1" ]]
-[[ "$(tmux show-options -gqv '@deep-history-auto-start')" == "off" ]]
+HOME_BACKFILLED=0
+for _ in $(seq 1 200); do
+    if [[ "$(tmux display-message -p -t "$HOME_PANE_ID" '#{pane_pipe}')" == "1" ]] \
+        && [[ "$(tmux show-options -pqv -t "$HOME_PANE_ID" '@deep-history-owned')" == "1" ]]; then
+        HOME_BACKFILLED=1
+        break
+    fi
+    sleep 0.05
+done
+[[ "$HOME_BACKFILLED" == "1" ]]
+
+# A pane created after auto-start is enabled must be claimed by the installed
+# global hook without another codex-add invocation.
+AUTO_PANE_ID="$(
+    tmux new-window -d -t "$SESSION" -P -F '#{pane_id}' -n auto-history \
+        "$TEMP_DIR/bin/fake-agent"
+)"
+AUTO_STARTED=0
+for _ in $(seq 1 200); do
+    if [[ "$(tmux display-message -p -t "$AUTO_PANE_ID" '#{pane_pipe}')" == "1" ]] \
+        && [[ "$(tmux show-options -pqv -t "$AUTO_PANE_ID" '@deep-history-owned')" == "1" ]]; then
+        AUTO_STARTED=1
+        break
+    fi
+    sleep 0.05
+done
+[[ "$AUTO_STARTED" == "1" ]]
+
+[[ "$(tmux show-options -gqv '@deep-history-auto-start')" == "on" ]]
+[[ "$(tmux show-options -gqv '@deep-history-seamless-pageup')" == "on" ]]
+[[ "$(tmux show-options -gqv history-limit)" == "50000" ]]
+tmux list-keys -T copy-mode | grep -q 'PPage.*tmux-deep-history.*view.*--older'
+tmux list-keys -T copy-mode-vi | grep -q 'PPage.*tmux-deep-history.*view.*--older'
 
 tmux send-keys -t "$PANE_ID" 'integration-marker' Enter
 

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -278,7 +278,7 @@ esac
         make_executable(
             deep_history,
             "#!/usr/bin/env bash\n"
-            f"printf 'python=%s command=%s\\n' \"${{TMUX_DEEP_HISTORY_PYTHON:-}}\" \"$*\" >> {deep_history_log}\n"
+            f'printf \'python=%s command=%s\\n\' "${{TMUX_DEEP_HISTORY_PYTHON:-}}" "$*" >> {deep_history_log}\n'
             "exit 0\n",
         )
         env = self.env.copy()
@@ -303,8 +303,7 @@ esac
         )
         self.assertTrue(
             any(
-                "@deep-history-seamless-pageup on" in " ".join(command)
-                for command in tmux_commands
+                "@deep-history-seamless-pageup on" in " ".join(command) for command in tmux_commands
             )
         )
         deep_commands = []
@@ -324,8 +323,7 @@ esac
         )
         self.assertTrue(
             any(
-                command[:4]
-                == ["set-environment", "-g", "TMUX_DEEP_HISTORY_PYTHON", sys.executable]
+                command[:4] == ["set-environment", "-g", "TMUX_DEEP_HISTORY_PYTHON", sys.executable]
                 for command in tmux_commands
             )
         )

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -3,7 +3,9 @@ import shutil
 import socket
 import stat
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -31,6 +33,12 @@ case "$1" in
     ;;
   new-window)
     echo "1"
+    exit 0
+    ;;
+  list-panes)
+    if [[ -n "${TMUX_LIST_PANES_OUTPUT:-}" ]]; then
+      printf '%b\n' "$TMUX_LIST_PANES_OUTPUT"
+    fi
     exit 0
     ;;
   *)
@@ -243,18 +251,40 @@ esac
         self.assertIn("Started codex in codexfarm:1", result.stdout)
         self.assertIn("warning: unable to attach log pipe", result.stderr)
 
-    def test_codex_add_uses_deep_history_as_single_pipe_owner(self):
+    def test_codex_add_auto_backend_reports_missing_deep_history(self):
+        target_dir = self.tmpdir / "proj-auto-history-fallback"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        env = self.env.copy()
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("tmux-deep-history is not installed", result.stderr)
+        self.assertIn("setup.sh --with-deep-history", result.stderr)
+        self.assertIn("History backend: legacy", result.stdout)
+
+    def test_codex_add_auto_uses_deep_history_as_single_pipe_owner(self):
         target_dir = self.tmpdir / "proj-deep-history"
         target_dir.mkdir(parents=True, exist_ok=True)
         deep_history_log = self.tmpdir / "deep-history.log"
         deep_history = self.tmpdir / "tmux-deep-history"
         make_executable(
             deep_history,
-            f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> {deep_history_log}\nexit 0\n",
+            "#!/usr/bin/env bash\n"
+            f"printf 'python=%s command=%s\\n' \"${{TMUX_DEEP_HISTORY_PYTHON:-}}\" \"$*\" >> {deep_history_log}\n"
+            "exit 0\n",
         )
         env = self.env.copy()
-        env["CODEXFARM_HISTORY_BACKEND"] = "deep-history"
         env["CODEXFARM_DEEP_HISTORY_BIN"] = str(deep_history)
+        env["CODEXFARM_DEEP_HISTORY_PYTHON_BIN"] = sys.executable
+        env["TMUX_LIST_PANES_OUTPUT"] = "0:"
         env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
 
         result = subprocess.run(
@@ -271,9 +301,50 @@ esac
         self.assertTrue(
             any("@deep-history-auto-start off" in " ".join(command) for command in tmux_commands)
         )
-        deep_commands = deep_history_log.read_text(encoding="utf-8").splitlines()
-        self.assertEqual(deep_commands[0], "install")
-        self.assertIn("start -t codexfarm:1 --mirror-output", deep_commands[1])
+        self.assertTrue(
+            any(
+                "@deep-history-seamless-pageup on" in " ".join(command)
+                for command in tmux_commands
+            )
+        )
+        deep_commands = []
+        for _ in range(100):
+            deep_commands = deep_history_log.read_text(encoding="utf-8").splitlines()
+            if len(deep_commands) >= 3:
+                break
+            time.sleep(0.01)
+        self.assertEqual(deep_commands[0], f"python={sys.executable} command=install")
+        self.assertIn(
+            f"python={sys.executable} command=start -t codexfarm:1 --mirror-output",
+            deep_commands[1],
+        )
+        self.assertEqual(deep_commands[2], f"python={sys.executable} command=start-all")
+        self.assertTrue(
+            any("@deep-history-auto-start on" in " ".join(command) for command in tmux_commands)
+        )
+        self.assertTrue(
+            any(
+                command[:4]
+                == ["set-environment", "-g", "TMUX_DEEP_HISTORY_PYTHON", sys.executable]
+                for command in tmux_commands
+            )
+        )
+        self.assertTrue(
+            any(
+                command[:5]
+                == [
+                    "set-environment",
+                    "-t",
+                    "codexfarm",
+                    "TMUX_DEEP_HISTORY_PYTHON",
+                    sys.executable,
+                ]
+                for command in tmux_commands
+            )
+        )
+        new_window = next(command for command in tmux_commands if command[0] == "new-window")
+        self.assertIn("-e", new_window)
+        self.assertIn(f"TMUX_DEEP_HISTORY_PYTHON={sys.executable}", new_window)
         self.assertIn("History backend: deep-history", result.stdout)
         log_files = list((Path(env["XDG_STATE_HOME"]) / "codexfarm" / "logs").glob("*.log"))
         self.assertEqual(len(log_files), 1)
@@ -307,6 +378,12 @@ esac
         self.assertIn("falling back to legacy pane logging", result.stderr)
         self.assertIn("simulated start failure", result.stderr)
         self.assertIn("History backend: legacy", result.stdout)
+        self.assertFalse(
+            any(
+                "@deep-history-auto-start on" in " ".join(command)
+                for command in self.read_tmux_commands()
+            )
+        )
 
     def test_codex_add_rejects_invalid_history_backend(self):
         target_dir = self.tmpdir / "proj-invalid-history"
@@ -324,6 +401,47 @@ esac
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("Invalid CODEXFARM_HISTORY_BACKEND", result.stderr)
+
+    def test_codex_add_legacy_backend_disables_deep_history_hooks(self):
+        target_dir = self.tmpdir / "proj-legacy-history"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        env = self.env.copy()
+        env["CODEXFARM_HISTORY_BACKEND"] = "legacy"
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("History backend: legacy", result.stdout)
+        self.assertTrue(
+            any(
+                "@deep-history-auto-start off" in " ".join(command)
+                for command in self.read_tmux_commands()
+            )
+        )
+
+    def test_codex_add_rejects_invalid_deep_history_pageup_setting(self):
+        target_dir = self.tmpdir / "proj-invalid-history-pageup"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        env = self.env.copy()
+        env["CODEXFARM_DEEP_HISTORY_SEAMLESS_PAGEUP"] = "sometimes"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Invalid CODEXFARM_DEEP_HISTORY_SEAMLESS_PAGEUP", result.stderr)
 
     def test_gemini_add_uses_named_session(self):
         target_dir = self.tmpdir / "proj-gemini"

--- a/tests/test_claude_hybrid.py
+++ b/tests/test_claude_hybrid.py
@@ -907,12 +907,8 @@ class ClaudeHybridTests(unittest.TestCase):
             started_at = time.time()
             current_path = session_root / f"rollout-current-{SESSION_ID}.jsonl"
             old_path = session_root / "rollout-old-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl"
-            current_timestamp = datetime.fromtimestamp(
-                started_at + 1, tz=timezone.utc
-            ).isoformat()
-            old_timestamp = datetime.fromtimestamp(
-                started_at - 3600, tz=timezone.utc
-            ).isoformat()
+            current_timestamp = datetime.fromtimestamp(started_at + 1, tz=timezone.utc).isoformat()
+            old_timestamp = datetime.fromtimestamp(started_at - 3600, tz=timezone.utc).isoformat()
             write_jsonl(
                 current_path,
                 [
@@ -1012,9 +1008,7 @@ class ClaudeHybridTests(unittest.TestCase):
         controller.ensure_started(timeout_seconds=5)
 
         skip_commands = [
-            command
-            for command in commands
-            if command[:3] == ["tmux", "send-keys", "-t"]
+            command for command in commands if command[:3] == ["tmux", "send-keys", "-t"]
         ]
         self.assertEqual(skip_commands, [["tmux", "send-keys", "-t", "%9", "2", "Enter"]])
 

--- a/tests/test_deep_history_installer.py
+++ b/tests/test_deep_history_installer.py
@@ -126,7 +126,7 @@ class DeepHistoryInstallerTests(unittest.TestCase):
             (fake_bin / "python3").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
             (fake_bin / "python3").chmod(0o755)
             (fake_bin / "python3.12").write_text(
-                "#!/bin/sh\nprintf '%s\\n' \"$0\" > \"$SELECTED_PYTHON_LOG\"\n",
+                '#!/bin/sh\nprintf \'%s\\n\' "$0" > "$SELECTED_PYTHON_LOG"\n',
                 encoding="utf-8",
             )
             (fake_bin / "python3.12").chmod(0o755)
@@ -147,7 +147,9 @@ class DeepHistoryInstallerTests(unittest.TestCase):
             )
 
             self.assertEqual(launched.returncode, 0, launched.stderr)
-            self.assertEqual(selected.read_text(encoding="utf-8").strip(), str(fake_bin / "python3.12"))
+            self.assertEqual(
+                selected.read_text(encoding="utf-8").strip(), str(fake_bin / "python3.12")
+            )
 
     def test_checksum_failure_preserves_previous_install(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_deep_history_installer.py
+++ b/tests/test_deep_history_installer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import stat
 import subprocess
 import sys
@@ -18,6 +19,22 @@ def build_archive(path: Path, *, unsafe_name: str | None = None) -> str:
         "tmux-deep-history/VERSION": (b"0.1.0\n", 0o644),
         "tmux-deep-history/tmux-deep-history.tmux": (b"#!/usr/bin/env bash\n", 0o755),
         "tmux-deep-history/bin/tmux-deep-history": (b"#!/usr/bin/env bash\n", 0o755),
+        "tmux-deep-history/src/tmux_deep_history/__init__.py": (b"", 0o644),
+        "tmux-deep-history/src/tmux_deep_history/tmux.py": (
+            b"class TmuxError(RuntimeError):\n"
+            b"    pass\n"
+            b"class PaneInfo:\n"
+            b"    def __init__(self, **values):\n"
+            b"        self.__dict__.update(values)\n"
+            b"class Tmux:\n"
+            b"    def start_pipe(self, target, command, *, only_if_none=True):\n"
+            b"        pass\n",
+            0o644,
+        ),
+        "tmux-deep-history/src/tmux_deep_history/cli.py": (
+            b"import sys\nprint('arguments=' + ' '.join(sys.argv[1:]))\n",
+            0o644,
+        ),
     }
     if unsafe_name is not None:
         files[unsafe_name] = (b"unsafe\n", 0o644)
@@ -70,12 +87,67 @@ class DeepHistoryInstallerTests(unittest.TestCase):
             cli = destination / "bin" / "tmux-deep-history"
             self.assertTrue(cli.is_file())
             self.assertNotEqual(cli.stat().st_mode & 0o111, 0)
+            self.assertTrue((destination / "bin" / "tmux-deep-history-upstream").is_file())
+            configured_python = destination / "bin" / ".codexfarm-python"
+            self.assertEqual(
+                configured_python.read_text(encoding="utf-8").strip(),
+                str(Path(sys.executable).resolve()),
+            )
+            self.assertEqual(configured_python.stat().st_mode & 0o777, 0o600)
+            launched = subprocess.run(
+                [cli, "status"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(launched.returncode, 0, launched.stderr)
+            self.assertEqual(launched.stdout.strip(), "arguments=status")
 
             (destination / "obsolete.txt").write_text("old\n", encoding="utf-8")
             second = self.run_installer(archive=archive, lock=lock, destination=destination)
             self.assertEqual(second.returncode, 0, second.stderr)
             self.assertFalse((destination / "obsolete.txt").exists())
             self.assertEqual((destination / "VERSION").read_text(encoding="utf-8"), "0.1.0\n")
+
+    def test_launcher_falls_back_to_supported_versioned_python(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "release.zip"
+            lock = root / "release.lock"
+            destination = root / "data" / "tmux-deep-history"
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            write_lock(lock, build_archive(archive))
+
+            result = self.run_installer(archive=archive, lock=lock, destination=destination)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            (destination / "bin" / ".codexfarm-python").unlink()
+
+            (fake_bin / "python3").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            (fake_bin / "python3").chmod(0o755)
+            (fake_bin / "python3.12").write_text(
+                "#!/bin/sh\nprintf '%s\\n' \"$0\" > \"$SELECTED_PYTHON_LOG\"\n",
+                encoding="utf-8",
+            )
+            (fake_bin / "python3.12").chmod(0o755)
+            selected = root / "selected-python"
+            env = os.environ.copy()
+            env.pop("TMUX_DEEP_HISTORY_PYTHON", None)
+            env.pop("CODEXFARM_DEEP_HISTORY_PYTHON_BIN", None)
+            env.pop("CODEXFARM_PYTHON_BIN", None)
+            env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+            env["SELECTED_PYTHON_LOG"] = str(selected)
+
+            launched = subprocess.run(
+                [destination / "bin" / "tmux-deep-history", "status"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(launched.returncode, 0, launched.stderr)
+            self.assertEqual(selected.read_text(encoding="utf-8").strip(), str(fake_bin / "python3.12"))
 
     def test_checksum_failure_preserves_previous_install(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -81,6 +81,42 @@ class SetupScriptTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--with-deep-history", result.stdout)
 
+    def test_sourced_setup_forwards_deep_history_flag(self) -> None:
+        (self.bin_dir / "python3").unlink()
+        (self.bin_dir / "python3").symlink_to(sys.executable)
+        make_executable(self.bin_dir / "tmux", "#!/usr/bin/env bash\nexit 0\n")
+        make_executable(self.bin_dir / "multitail", "#!/usr/bin/env bash\nexit 0\n")
+        archive = self.tmpdir / "tmux-deep-history.zip"
+        lock = self.tmpdir / "tmux-deep-history.lock"
+        write_lock(lock, build_archive(archive))
+        self.env["CODEXFARM_DEEP_HISTORY_ARCHIVE"] = str(archive)
+        self.env["CODEXFARM_DEEP_HISTORY_LOCK_FILE"] = str(lock)
+
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                f'. "{REPO_ROOT / "setup.sh"}" --with-deep-history',
+            ],
+            cwd=REPO_ROOT,
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        installed = (
+            Path(self.env["HOME"])
+            / ".local"
+            / "share"
+            / "codexfarm"
+            / "plugins"
+            / "tmux-deep-history"
+        )
+        self.assertTrue((installed / "bin" / "tmux-deep-history").is_file())
+        self.assertIn("Installed tmux-deep-history 0.1.0", result.stdout)
+
     def test_with_deep_history_installs_pinned_local_release(self) -> None:
         (self.bin_dir / "python3").unlink()
         (self.bin_dir / "python3").symlink_to(sys.executable)
@@ -105,6 +141,22 @@ class SetupScriptTests(unittest.TestCase):
         )
         self.assertTrue((installed / "bin" / "tmux-deep-history").is_file())
         self.assertIn("Installed tmux-deep-history 0.1.0", result.stdout)
+
+    def test_with_deep_history_without_installer_overrides_works_under_nounset(self) -> None:
+        python_log = self.tmpdir / "python.log"
+        self.env["FAKE_PYTHON_LOG"] = str(python_log)
+
+        result = self.run_setup("--with-deep-history")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        invocations = python_log.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(
+            any(
+                invocation.endswith("integrations/install_tmux_deep_history.py")
+                for invocation in invocations
+            ),
+            invocations,
+        )
 
     def test_skips_package_manager_when_dependencies_already_exist(self) -> None:
         make_executable(self.bin_dir / "tmux", "#!/usr/bin/env bash\nexit 0\n")


### PR DESCRIPTION
## What changed

- enable deep-history recording for existing panes and future panes through global tmux hooks
- preserve the farm compatibility log while deep-history owns the single pane pipe
- install a pinned compatibility launcher that selects Python 3.10+, fixes pane `%0` escaping and logger startup races, and batches tmux reads for responsive popups
- enable seamless Page Up handoff at the top of tmux copy-mode history
- make existing-pane backfill conditional and asynchronous
- document the disk-history behavior, global recording scope, and opt-out controls
- expand unit and isolated tmux integration coverage for installation, backfill, automatic future panes, bindings, mirroring, and teardown

## Why

The popup could open empty because no panes were actually being recorded. On macOS, repeated Python probes could also exceed the logger readiness deadline, upstream session-targeted backfill only visited one active window, and pane `%0` was consumed by tmux shell-command formatting. Together those failures made the feature look installed while leaving no durable transcript to display.

## Impact

Deep history now starts automatically after opt-in, current panes are backfilled unless another pipe owns them, new panes are captured by hooks, legacy flat logs remain compatible, and the popup opens against populated history with substantially lower startup latency. Explicit legacy mode disables the global hooks.

## Validation

- focused deep-history installer and lifecycle unit tests
- `tests/integration/deep_history_smoke.sh`
- `./validate.sh`
- live verification of 12 active pane loggers, Page Up bindings, auto-start hooks, mirrored output, and popup rendering