### PR TITLE
Fix exact coding-agent session restore identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ backward compatibility.
 - **Durable pane history**: Optional tmux-deep-history integration adds rotated raw/normalized transcripts, a seamless Page Up handoff beyond tmux's in-memory buffer, and compatible timestamped farm logs
 - **Unified monitoring**: Watch all agent instances from a single consolidated view
 - **Fast navigation**: Optional "board" session for quick switching between instances
-- **Snapshot/restore**: Save a manifest of windows and restore them later
+- **Exact snapshot/restore**: Save each provider conversation by ID and restore
+  every manifest row independently
 - **Status updates**: Tracks RUN/READY/ERR in tmux metadata and notifies when a window becomes READY
 - **Memory warnings**: Flag tmux windows whose pane process trees exceed a chosen RSS threshold
 - **Autosave/autorestore (optional)**: Systemd user services to persist sessions across logins
@@ -25,7 +26,8 @@ backward compatibility.
 - `tmux` for farm sessions, boards, status inspection, save/restore, and farm-launched loopers.
 - The selected provider executable on `PATH` (`codex`, `claude`, `gemini`, or a custom command).
 - Optional `multitail` for the richer `codex-watch` view. Without it, watch falls back to `tail`.
-- Optional `lsof` so save/restore can find exact live provider session files.
+- Optional `lsof` improves exact-session discovery for Claude, Gemini, and
+  Codex panes whose lifecycle hook has not run.
 - Git only for looper backup branches and git-progress circuit breakers.
 - Systemd user services only for autosave/autorestore.
 - Optional network access during `setup.sh --with-deep-history` to download the checksum-pinned plugin release.
@@ -36,8 +38,9 @@ backward compatibility.
 
 ### 1. One-time Setup
 
-Run the setup script to create helper scripts, install the pinned deep-history integration, and
-auto-reload your shell:
+Run the setup script to create helper scripts, install the Codex
+session-identity hook and pinned deep-history integration, and auto-reload your
+shell:
 
 ```bash
 source ./setup.sh --with-deep-history
@@ -46,6 +49,7 @@ source ./setup.sh --with-deep-history
 This will:
 - Report missing `tmux` and `multitail` commands without running package-manager installs
 - Create helper scripts in `$HOME/bin/`
+- Merge the session-identity hook into `${CODEX_HOME:-~/.codex}/hooks.json`
 - Set up logging directories
 - Add `$HOME/bin` to your PATH automatically (bash/zsh/fish) and the current session
 - Verify and install the pinned `tmux-deep-history` release under `$XDG_DATA_HOME/codexfarm/plugins/` (or `~/.local/share/codexfarm/plugins/`)
@@ -53,6 +57,21 @@ This will:
 If `tmux` is unavailable, core tmux commands will not work until you install it. If `multitail` is unavailable, `codex-watch` falls back to a simpler `tail` view.
 Omit `--with-deep-history` when you want the legacy flat-log backend only. Re-running the setup
 command is safe; the installed version can change only when this repository's reviewed lock changes.
+
+Codex requires review for non-managed command hooks. Open `/hooks` in Codex CLI
+after setup and trust the Agent CLI Farm hook. It receives the active Codex
+`session_id` on `SessionStart` and `UserPromptSubmit`, then records it as an
+invisible tmux pane option. Use `./setup.sh --without-session-hook` (or
+`CODEXFARM_INSTALL_SESSION_HOOK=0`) when you do not want setup to change the
+user hook file.
+
+To explicitly inspect the ID recorded for the current pane, run this inside that
+pane (the command intentionally prints the otherwise hidden conversation ID):
+
+```bash
+tmux show-options -p -v -t "$TMUX_PANE" @codexfarm_session_id
+tmux show-options -p -v -t "$TMUX_PANE" @codexfarm_session_source
+```
 
 Deep history is intentionally opt-in because terminal transcripts can contain commands, private
 paths, credentials, and other sensitive output. Once installed, the default `auto` backend starts
@@ -201,6 +220,9 @@ CODEX_SESSION=work codex-save
 # writes to ~/.config/codexfarm/manifests/work.tsv
 codex-save --all-registered
 # writes one manifest per farm registered for autoservice
+
+# Explicitly permit legacy latest-session fallbacks:
+codex-save --allow-fallback
 ```
 
 Restore them later (e.g., after reboot or on SSH login):
@@ -214,6 +236,7 @@ Reboot a running farm through the complete save, stop, and restore sequence:
 codex-farm-reboot              # reboot the default farm and attach
 codex-farm-reboot --detach     # restore without attaching
 codex-farm-reboot work         # reboot the named "work" farm
+codex-farm-reboot --allow-fallback --detach
 claude-farm-reboot --detach    # use Claude defaults for fallback restore commands
 gemini-farm-reboot --detach    # use Gemini defaults for fallback restore commands
 ```
@@ -225,7 +248,18 @@ board that is currently hosting the command. Checkpoint active agent work first 
 exact provider-session discovery is best-effort.
 
 Use `-f` to force re-creation of existing-named windows.
-Saved Codex, Claude, and Gemini windows restore with exact session IDs when `codex-save` can read the live session file from the pane's process tree. If the exact session is unavailable, restore falls back by tool: `codex resume --last`, `claude --continue`, or `gemini --resume latest`.
+Managed panes keep a stable logical name in tmux metadata even while a CLI
+changes its visible native title. Duplicate logical names are valid: restore
+matches the first manifest occurrence to the first existing window, the second
+to the second, and so on. Force restore removes all matching occurrences before
+recreating every row.
+
+Saved Codex, Claude, and Gemini windows require exact session IDs by default.
+Codex first uses fresh hook metadata owned by the pane's current provider
+process; all providers can fall back to live session-file discovery. If any
+recognized provider ID is unresolved, `codex-save` exits nonzero and leaves the
+previous manifest intact. `--allow-fallback` explicitly permits
+`codex resume --last`, `claude --continue`, or `gemini --resume latest`.
 Only pane 0 is saved. Split layouts and scrollback are not reconstructed. Missing saved directories fall back to `$HOME` with a warning.
 Manifests are written owner-only and via atomic replacement, but they are still trusted executable input because restore launches the recorded commands.
 
@@ -237,7 +271,10 @@ CODEX_SESSION=work codex-doctor
 codex-doctor --source /path/to/agent-cli-farm /path/to/manifest.tsv
 ```
 
-The doctor exits nonzero for stale or missing installed helpers, malformed or unsafe manifests, blank commands, and provider fallbacks that could resume the wrong conversation.
+The doctor exits nonzero for stale or missing installed helpers, malformed or
+unsafe manifests, blank commands, non-UUID or fallback provider resumes, and
+duplicate logical names. Duplicate names are supported by restore, but the
+warning makes them explicit before destructive force restores.
 
 If tmux sessions are already running (no manifest needed):
 ```bash
@@ -314,9 +351,9 @@ Tuning and controls:
 - **`codex-board [create|link|switch] [session]`** - Manage the default or a named board session for navigation
 - **`codex-resume [session] [--board]`** - Attach/switch to an existing Codex/tmux session or named farm board
 - **`codex-doctor [--session NAME] [--source DIR] [manifest]`** - Check installed-helper freshness and manifest resume coverage without displaying session IDs
-- **`codex-save [manifest]`** - Snapshot current windows to a manifest (TSV)
+- **`codex-save [--allow-fallback] [manifest]`** - Snapshot current windows to a manifest (TSV), requiring exact provider IDs by default
 - **`codex-restore [-a] [-f] [manifest]`** - Restore windows from a manifest
-- **`codex-farm-reboot [--detach] [session]`** - Safely save, stop, restore, and optionally attach to a farm
+- **`codex-farm-reboot [--detach] [--allow-fallback] [session]`** - Safely save, stop, restore, and optionally attach to a farm
 
 ### Claude and Gemini Wrappers
 
@@ -343,6 +380,7 @@ Common:
 - **`CODEX_ANNOTATOR_PYTHON_BIN`** - Python 3.10+ interpreter for `codex-annotator` (default searches `python3`, then versioned `python3.14` through `python3.10`)
 - **`CODEXFARM_PYTHON_BIN`** - Python 3.10+ interpreter to prefer during `./setup.sh`
 - **`CODEXFARM_WITH_DEEP_HISTORY`** - set to `1` as an alternative to `setup.sh --with-deep-history`
+- **`CODEXFARM_INSTALL_SESSION_HOOK`** - set to `0` to leave the Codex user hook file unchanged during setup
 - **`CODEXFARM_HISTORY_BACKEND`** - `auto` (default), `legacy`, or `deep-history`; auto uses the pinned plugin when installed and otherwise preserves legacy logging
 - **`CODEXFARM_DEEP_HISTORY_BIN`** - override the deep-history executable discovered under the XDG data directory
 - **`CODEXFARM_DEEP_HISTORY_PYTHON_BIN`** - override the Python 3.10+ interpreter used by deep-history hooks and loggers (default searches supported `python3` and versioned commands)
@@ -373,7 +411,8 @@ CODEX_CMD="cursor" CODEX_ARGS="--wait" codex-add /my/project
 Flags:
 - `codex-add -d`: start without attaching (useful in SSH automation)
 - `codex-restore -a`: attach after restoring; `-f` to replace same-named windows
-- `codex-farm-reboot -d`: save, stop, and restore without attaching
+- `codex-save --allow-fallback`: explicitly allow provider latest/continue resume commands
+- `codex-farm-reboot -d`: save, stop, and restore without attaching; add `--allow-fallback` only when exact identity cannot be recovered
 
 ## Advanced Usage
 
@@ -480,6 +519,8 @@ agent-cli-farm/
 │   ├── codex-doctor   # Diagnose installed-helper and manifest drift
 │   ├── codex-save     # Save manifest of windows
 │   ├── codex-restore  # Restore windows from manifest
+│   ├── codex-session-hook.py # Record active Codex IDs on managed tmux panes
+│   ├── codex-session-hook-install.py # Safely merge the user hook config
 │   ├── codex-farm-reboot # Save, stop, and restore a farm
 │   ├── codex-watch    # Monitor logs
 │   ├── codex-board    # Navigation helper
@@ -504,7 +545,11 @@ agent-cli-farm/
 - `tmux` survives client disconnects, but not host reboot or tmux-server exit unless autosave/autorestore recreates windows later.
 - Autosave/autorestore is systemd-user-only.
 - tmux provides one `pipe-pane` consumer per pane; the deep-history backend owns it and mirrors the stream rather than attaching a competing logger.
-- Manifest `cmd/args` are best-effort when saving from existing panes. Exact session IDs are captured from live processes when `lsof` can see the open session file: Codex under `~/.codex/sessions`, Claude under `~/.claude/projects`, and Gemini under a `.gemini/.../chats` directory. Missing IDs fall back to each tool's latest/continue behavior.
+- Existing panes created before the session hook was installed may need one
+  submitted Codex prompt before hook metadata appears. Save also inspects live
+  process file descriptors: Codex under `~/.codex/sessions`, Claude under
+  `~/.claude/projects`, and Gemini under a `.gemini/.../chats` directory.
+  Missing provider IDs stop save unless fallback behavior is explicitly enabled.
 - A single positional argument to `codex-add` is interpreted as a farm name when it does not look like a path. Use `--session NAME` to force farm selection when needed.
 - Gemini looper support is generic command execution, not a verified resumable protocol.
 

--- a/bin/codex-add
+++ b/bin/codex-add
@@ -250,6 +250,11 @@ BOARD_SESSION="$(board_session_name "$SESSION" "$DEFAULT_SESSION")"
 DIR="${dir_arg:-$PWD}"
 NAME="$(get_env NAME "$(basename "$DIR")")"
 CMD="$(get_env CMD "$tool_name")"
+PANE_PROVIDER=""
+case "${CMD##*/}" in
+  codex|claude|gemini) PANE_PROVIDER="${CMD##*/}" ;;
+esac
+HOOK_PROVIDER="${PANE_PROVIDER:-$tool_name}"
 ARGS_ENV="$(get_env ARGS "")"
 LOCK_TITLES="$(get_env LOCK_TITLES 0)"
 ANNOTATOR_AUTOSTART="$(get_env ANNOTATOR_AUTOSTART 1)"
@@ -690,9 +695,27 @@ fi
 
 if [ "$SELECTED_HISTORY_BACKEND" = "deep-history" ]; then
   WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" \
+    -e "CODEXFARM_MANAGED=1" -e "CODEXFARM_PROVIDER=$HOOK_PROVIDER" \
+    -e "CODEXFARM_WINDOW_NAME=$NAME" \
     -e "TMUX_DEEP_HISTORY_PYTHON=$DEEP_HISTORY_PYTHON_BIN" "$WINDOW_CMDLINE")
 else
-  WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" "$WINDOW_CMDLINE")
+  WIN=$(tmux new-window -t "$SESSION" -P -F "#{window_index}" -n "$NAME" -c "$DIR" \
+    -e "CODEXFARM_MANAGED=1" -e "CODEXFARM_PROVIDER=$HOOK_PROVIDER" \
+    -e "CODEXFARM_WINDOW_NAME=$NAME" "$WINDOW_CMDLINE")
+fi
+
+identity_failed=0
+if ! tmux set-option -p -t "$SESSION:$WIN.0" @codexfarm_name "$NAME"; then
+  identity_failed=1
+fi
+if [ -n "$PANE_PROVIDER" ] \
+  && ! tmux set-option -p -t "$SESSION:$WIN.0" \
+    @codexfarm_provider "$PANE_PROVIDER"
+then
+  identity_failed=1
+fi
+if [ "$identity_failed" -eq 1 ]; then
+  echo "warning: unable to set stable pane identity for $SESSION:$WIN" >&2
 fi
 
 if remain_on_exit_enabled; then

--- a/bin/codex-doctor
+++ b/bin/codex-doctor
@@ -116,7 +116,7 @@ check_installed_helpers() {
 check_manifest() {
   local manifest="$1"
   local header=""
-  local stats rows malformed blank exact fallback provider_invalid other
+  local stats rows malformed blank exact fallback provider_invalid other duplicates
   local mode=""
 
   if [ ! -f "$manifest" ]; then
@@ -136,10 +136,22 @@ check_manifest() {
   fi
 
   if ! stats="$(awk -F '\t' '
+    function valid_uuid(value, parts, count, part_index) {
+      count = split(value, parts, "-")
+      if (count != 5 || length(parts[1]) != 8 || length(parts[2]) != 4 \
+          || length(parts[3]) != 4 || length(parts[4]) != 4 \
+          || length(parts[5]) != 12) return 0
+      for (part_index = 1; part_index <= 5; part_index++) {
+        if (parts[part_index] ~ /[^0-9a-fA-F]/) return 0
+      }
+      return 1
+    }
     NR == 1 { next }
     {
       rows++
       if (NF != 4) malformed++
+      names[$1]++
+      if (names[$1] > 1) duplicates++
       cmd = $3
       args = $4
       if (cmd == "") {
@@ -148,21 +160,21 @@ check_manifest() {
         if (args == "resume --last") fallback++
         else {
           session_id = substr(args, 8)
-          if (index(args, "resume ") == 1 && session_id !~ /^--/ && session_id !~ /[[:space:]]/) exact++
+          if (index(args, "resume ") == 1 && valid_uuid(session_id)) exact++
           else provider_invalid++
         }
       } else if (cmd == "claude") {
         if (args == "--continue") fallback++
         else {
           session_id = substr(args, 10)
-          if (index(args, "--resume ") == 1 && session_id !~ /^-/ && session_id !~ /[[:space:]]/) exact++
+          if (index(args, "--resume ") == 1 && valid_uuid(session_id)) exact++
           else provider_invalid++
         }
       } else if (cmd == "gemini") {
         if (args == "--resume latest") fallback++
         else {
           session_id = substr(args, 10)
-          if (index(args, "--resume ") == 1 && session_id !~ /^-/ && session_id !~ /[[:space:]]/) exact++
+          if (index(args, "--resume ") == 1 && valid_uuid(session_id)) exact++
           else provider_invalid++
         }
       } else {
@@ -170,19 +182,19 @@ check_manifest() {
       }
     }
     END {
-      printf "%d\t%d\t%d\t%d\t%d\t%d\t%d\n", \
+      printf "%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n", \
         rows + 0, malformed + 0, blank + 0, exact + 0, fallback + 0, \
-        provider_invalid + 0, other + 0
+        provider_invalid + 0, other + 0, duplicates + 0
     }
   ' "$manifest")"; then
     problem "unable to inspect manifest rows: $manifest"
     return
   fi
-  IFS=$'\t' read -r rows malformed blank exact fallback provider_invalid other <<EOF
+  IFS=$'\t' read -r rows malformed blank exact fallback provider_invalid other duplicates <<EOF
 $stats
 EOF
 
-  info "manifest rows: $rows; exact provider sessions: $exact; fallback: $fallback; blank commands: $blank; other commands: $other"
+  info "manifest rows: $rows; exact provider sessions: $exact; fallback: $fallback; blank commands: $blank; other commands: $other; duplicate names: $duplicates"
   if [ "$rows" -eq 0 ]; then
     warning "manifest contains no saved windows"
   fi
@@ -198,8 +210,12 @@ EOF
   if [ "$provider_invalid" -gt 0 ]; then
     problem "manifest contains $provider_invalid provider command(s) with invalid resume arguments"
   fi
+  if [ "$duplicates" -gt 0 ]; then
+    warning "manifest contains $duplicates duplicate logical name occurrence(s); restore matches them by occurrence"
+  fi
   if [ "$rows" -gt 0 ] && [ "$malformed" -eq 0 ] && [ "$blank" -eq 0 ] \
-    && [ "$fallback" -eq 0 ] && [ "$provider_invalid" -eq 0 ]; then
+    && [ "$fallback" -eq 0 ] && [ "$provider_invalid" -eq 0 ] \
+    && [ "$duplicates" -eq 0 ]; then
     ok "manifest resume data is healthy"
   fi
 

--- a/bin/codex-farm-reboot
+++ b/bin/codex-farm-reboot
@@ -23,6 +23,7 @@ Options:
   -a, --attach           Attach or switch to the restored farm (default)
   -d, --detach           Restore without attaching
       --no-attach        Alias for --detach
+      --allow-fallback   Permit latest-session fallback during the save step
   -h, --help             Show this help
 
 Run this command outside the target farm and its board session. The saved
@@ -57,6 +58,7 @@ resolve_executable() {
 }
 
 attach=1
+allow_fallback=0
 session_arg=""
 positionals=()
 while (( "$#" )); do
@@ -74,6 +76,9 @@ while (( "$#" )); do
       ;;
     -d|--detach|--no-attach)
       attach=0
+      ;;
+    --allow-fallback)
+      allow_fallback=1
       ;;
     -h|--help)
       usage
@@ -164,7 +169,13 @@ if tmux has-session -t "$BOARD_SESSION" 2>/dev/null; then
 fi
 
 printf 'Saving farm %s...\n' "$SESSION"
-if ! CODEX_TOOL_NAME="$tool_name" CODEX_SESSION="$SESSION" "$SAVE_BIN"; then
+save_args=()
+if [ "$allow_fallback" -eq 1 ]; then
+  save_args+=("--allow-fallback")
+fi
+if ! CODEX_TOOL_NAME="$tool_name" CODEX_SESSION="$SESSION" \
+  "$SAVE_BIN" "${save_args[@]}"
+then
   echo "Save failed; farm '$SESSION' was not stopped." >&2
   exit 1
 fi

--- a/bin/codex-restore
+++ b/bin/codex-restore
@@ -63,10 +63,10 @@ strip_status_prefix() {
   printf '%s' "$value"
 }
 
-existing_window_target() {
+existing_window_targets() {
   local session="$1"
   local wanted_name="$2"
-  local line target name base_name
+  local line target name base_name stable_name
 
   while IFS= read -r line; do
     [ -z "$line" ] && continue
@@ -77,14 +77,38 @@ existing_window_target() {
       target="$line"
       name="$line"
     fi
-    base_name="$(strip_status_prefix "$name")"
+    stable_name="$(
+      tmux show-options -p -v -t "$target.0" @codexfarm_name 2>/dev/null || true
+    )"
+    if [ -n "$stable_name" ]; then
+      base_name="$stable_name"
+    else
+      base_name="$(strip_status_prefix "$name")"
+    fi
     if [ "$base_name" = "$wanted_name" ]; then
+      printf '%s\n' "$target"
+    fi
+  done < <(tmux list-windows -t "$session" -F $'#{window_id}\t#{window_name}')
+}
+
+existing_window_target() {
+  local session="$1"
+  local wanted_name="$2"
+  local wanted_occurrence="${3:-1}"
+  local target count=0
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    count=$((count + 1))
+    if [ "$count" -eq "$wanted_occurrence" ]; then
       printf '%s' "$target"
       return 0
     fi
-  done < <(tmux list-windows -t "$session" -F $'#{window_id}\t#{window_name}')
-
+  done < <(existing_window_targets "$session" "$wanted_name")
   return 1
+}
+
+valid_session_id() {
+  [[ "$1" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]
 }
 
 tool_from_command() {
@@ -151,6 +175,44 @@ normalize_restore_command() {
   if [ -z "$RESTORE_ARGS" ]; then
     RESTORE_ARGS="${CODEX_ARGS:-}"
   fi
+}
+
+exact_session_id_from_restore() {
+  local command="$1"
+  local args="$2"
+  local values=()
+  read -r -a values <<< "$args"
+  [ "${#values[@]}" -eq 2 ] || return 1
+  case "$command:${values[0]}" in
+    codex:resume|claude:--resume|gemini:--resume) ;;
+    *) return 1 ;;
+  esac
+  valid_session_id "${values[1]}" || return 1
+  printf '%s' "${values[1]}"
+}
+
+next_name_occurrence() {
+  local wanted="$1"
+  local index
+  for index in "${!seen_names[@]}"; do
+    if [ "${seen_names[$index]}" = "$wanted" ]; then
+      seen_counts[$index]=$((seen_counts[$index] + 1))
+      window_occurrence="${seen_counts[$index]}"
+      return
+    fi
+  done
+  seen_names+=("$wanted")
+  seen_counts+=(1)
+  window_occurrence=1
+}
+
+name_was_seen() {
+  local wanted="$1"
+  local value
+  for value in "${force_names[@]}"; do
+    [ "$value" = "$wanted" ] && return 0
+  done
+  return 1
 }
 
 DEFAULT_SESSION="codexfarm"
@@ -279,27 +341,81 @@ fi
 # Ensure session exists
 tmux has-session -t "$SESSION" 2>/dev/null || tmux new-session -d -s "$SESSION" -n home
 
+force_names=()
+if [ "$force" -eq 1 ]; then
+  {
+    IFS= read -r _header || true
+    while IFS=$'\t' read -r name _dir _cmd _args || [ -n "${name:-}" ]; do
+      [ -n "${name:-}" ] || continue
+      if name_was_seen "$name"; then
+        continue
+      fi
+      force_names+=("$name")
+      while IFS= read -r existing_target; do
+        [ -n "$existing_target" ] || continue
+        if ! tmux kill-window -t "$existing_target"; then
+          echo "Unable to remove existing window '$name' during force restore." >&2
+          exit 1
+        fi
+      done < <(existing_window_targets "$SESSION" "$name")
+    done
+  } < "$MANIFEST_PATH"
+fi
+
 # Read manifest; skip header
-{ read -r _header || true; cat; } < "$MANIFEST_PATH" | while IFS=$'\t' read -r name dir cmd args || [ -n "${name:-}" ]; do
-  [ -z "${name:-}" ] && continue
-  restore_dir="${dir:-$HOME}"
-  if [ ! -d "$restore_dir" ]; then
-    echo "Warning: saved directory not found, using HOME: $restore_dir" >&2
-    restore_dir="$HOME"
-  fi
-  # Skip if window exists and not forcing
-  existing_target="$(existing_window_target "$SESSION" "$name" || true)"
-  if [ -n "$existing_target" ]; then
-    if [ "$force" -eq 1 ]; then
-      tmux kill-window -t "$existing_target" || true
-    else
-      echo "Skipping existing window: $name"
-      continue
+seen_names=()
+seen_counts=()
+{
+  IFS= read -r _header || true
+  while IFS=$'\t' read -r name dir cmd args || [ -n "${name:-}" ]; do
+    [ -z "${name:-}" ] && continue
+    next_name_occurrence "$name"
+    restore_dir="${dir:-$HOME}"
+    if [ ! -d "$restore_dir" ]; then
+      echo "Warning: saved directory not found, using HOME: $restore_dir" >&2
+      restore_dir="$HOME"
     fi
-  fi
-  normalize_restore_command "${cmd:-}" "${args:-}"
-  CODEX_NAME="$name" CODEX_CMD="$RESTORE_CMD" CODEX_ARGS="$RESTORE_ARGS" "$ADD_BIN" -d "$restore_dir"
-done
+    if [ "$force" -eq 0 ]; then
+      existing_target="$(
+        existing_window_target "$SESSION" "$name" "$window_occurrence" || true
+      )"
+      if [ -n "$existing_target" ]; then
+        echo "Skipping existing window: $name"
+        continue
+      fi
+    fi
+    normalize_restore_command "${cmd:-}" "${args:-}"
+    restore_provider="$tool_name"
+    case "$RESTORE_CMD" in
+      codex|claude|gemini) restore_provider="$RESTORE_CMD" ;;
+    esac
+    CODEX_TOOL_NAME="$restore_provider" \
+      CODEX_NAME="$name" \
+      CODEX_CMD="$RESTORE_CMD" \
+      CODEX_ARGS="$RESTORE_ARGS" \
+      "$ADD_BIN" -d "$restore_dir"
+
+    exact_session_id="$(
+      exact_session_id_from_restore "$RESTORE_CMD" "$RESTORE_ARGS" || true
+    )"
+    if [ -n "$exact_session_id" ]; then
+      created_target="$(
+        existing_window_target "$SESSION" "$name" "$window_occurrence" || true
+      )"
+      if [ -n "$created_target" ]; then
+        if ! tmux set-option -p -t "$created_target.0" \
+          @codexfarm_provider "$RESTORE_CMD" >/dev/null 2>&1 \
+          || ! tmux set-option -p -t "$created_target.0" \
+            @codexfarm_session_source restore >/dev/null 2>&1 \
+          || ! tmux set-option -p -t "$created_target.0" \
+            @codexfarm_session_id "$exact_session_id" >/dev/null 2>&1
+        then
+          echo "Warning: unable to seed exact session metadata for window: $name" >&2
+        fi
+      fi
+    fi
+  done
+} < "$MANIFEST_PATH"
 
 if [ "$attach" -eq 1 ]; then
   attach_to_session "$SESSION"

--- a/bin/codex-save
+++ b/bin/codex-save
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 # Snapshot the current Codex tmux windows to a manifest file
-# Usage: codex-save [manifest-path]
+# Usage: codex-save [--allow-fallback] [manifest-path]
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--all-registered] [manifest-path]
+Usage: $(basename "$0") [--all-registered] [--allow-fallback] [manifest-path]
 
 Snapshot tmux farm windows to a trusted restore manifest.
+
+Recognized provider panes require an exact session ID by default. Use
+--allow-fallback to permit provider-specific latest-session resume commands.
 EOF
 }
 
@@ -67,6 +70,16 @@ extract_uuid_from_session_path() {
   if [[ "$base" =~ ([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}) ]]; then
     printf '%s' "${BASH_REMATCH[1]}"
   fi
+}
+
+valid_session_id() {
+  [[ "$1" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]
+}
+
+pane_option() {
+  local pane_target="$1"
+  local option="$2"
+  tmux show-options -p -v -t "$pane_target" "$option" 2>/dev/null || true
 }
 
 extract_session_id_from_metadata() {
@@ -291,34 +304,46 @@ provider_pid_from_process_tree() {
   printf '%s' "$fallback"
 }
 
-resume_args_for_pane() {
+session_id_for_pane() {
   local tool="$1"
-  local pane_pid="$2"
-  local provider_pid="${3:-}"
-  local session_id
+  local pane_target="$2"
+  local pane_pid="$3"
+  local provider_pid="${4:-}"
+  local pane_dead="${5:-0}"
+  local session_id metadata_pid
+
+  session_id="$(pane_option "$pane_target" @codexfarm_session_id)"
+  metadata_pid="$(pane_option "$pane_target" @codexfarm_session_pid)"
+  if valid_session_id "$session_id" \
+    && { [ "$pane_dead" = "1" ] \
+      || { [ -n "$provider_pid" ] && [ "$metadata_pid" = "$provider_pid" ]; }; }
+  then
+    printf '%s' "$session_id"
+    return 0
+  fi
+
   session_id="$(session_id_from_process_files "$tool" "$pane_pid" "$provider_pid" || true)"
+  if valid_session_id "$session_id"; then
+    printf '%s' "$session_id"
+    return 0
+  fi
+  return 1
+}
+
+exact_resume_args() {
+  local tool="$1"
+  local session_id="$2"
   case "$tool" in
-    codex)
-      if [ -n "$session_id" ]; then
-        printf 'resume %s' "$session_id"
-      else
-        printf 'resume --last'
-      fi
-      ;;
-    claude)
-      if [ -n "$session_id" ]; then
-        printf -- '--resume %s' "$session_id"
-      else
-        printf -- '--continue'
-      fi
-      ;;
-    gemini)
-      if [ -n "$session_id" ]; then
-        printf -- '--resume %s' "$session_id"
-      else
-        printf -- '--resume latest'
-      fi
-      ;;
+    codex) printf 'resume %s' "$session_id" ;;
+    claude|gemini) printf -- '--resume %s' "$session_id" ;;
+  esac
+}
+
+fallback_resume_args() {
+  case "$1" in
+    codex) printf 'resume --last' ;;
+    claude) printf -- '--continue' ;;
+    gemini) printf -- '--resume latest' ;;
   esac
 }
 
@@ -341,8 +366,12 @@ default_manifest_path_for_session() {
 
 save_all_registered() {
   local session manifest status count
+  local recursive_args=()
   status=0
   count=0
+  if [ "$allow_fallback" -eq 1 ]; then
+    recursive_args+=("--allow-fallback")
+  fi
   if [ ! -f "$AUTOSERVICE_REGISTRY" ]; then
     echo "No registered farms found at $AUTOSERVICE_REGISTRY"
     return 0
@@ -355,7 +384,7 @@ save_all_registered() {
     if [ -z "${manifest:-}" ]; then
       manifest="$(default_manifest_path_for_session "$session")"
     fi
-    if CODEX_SESSION="$session" "$0" "$manifest"; then
+    if CODEX_SESSION="$session" "$0" "${recursive_args[@]}" "$manifest"; then
       count=$((count + 1))
     else
       status=1
@@ -367,6 +396,7 @@ save_all_registered() {
 }
 
 all_registered=0
+allow_fallback=0
 args_pos=()
 while (( "$#" )); do
   case "${1:-}" in
@@ -376,6 +406,10 @@ while (( "$#" )); do
       ;;
     --all-registered)
       all_registered=1
+      shift
+      ;;
+    --allow-fallback)
+      allow_fallback=1
       shift
       ;;
     --)
@@ -431,20 +465,34 @@ chmod 600 "$tmpfile" 2>/dev/null || true
 trap 'rm -f "$tmpfile"' EXIT
 
 printf 'name\tdir\tcmd\targs\n' > "$tmpfile"
+unresolved_sessions=0
 
 # Collect windows, skipping the initial 'home' window if present
 while IFS=$'\n' read -r idx; do
+  pane_target="$SESSION:$idx.0"
   name=$(tmux display-message -p -t "$SESSION:$idx" '#{window_name}')
   name=$(strip_status_prefix "$name")
+  stable_name="$(pane_option "$pane_target" @codexfarm_name)"
+  if [ -n "$stable_name" ]; then
+    name="$stable_name"
+  fi
   [ "$name" = "home" ] && continue
   # Prefer the first pane's path
-  dir=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_current_path}')
+  dir=$(tmux display-message -p -t "$pane_target" '#{pane_current_path}')
   # Best-effort: starting command (often sh/bash for a long-lived pane)
-  cmd=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_start_command}')
-  current_cmd=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_current_command}')
-  pane_pid=$(tmux display-message -p -t "$SESSION:$idx.0" '#{pane_pid}')
+  cmd=$(tmux display-message -p -t "$pane_target" '#{pane_start_command}')
+  current_cmd=$(tmux display-message -p -t "$pane_target" '#{pane_current_command}')
+  pane_pid=$(tmux display-message -p -t "$pane_target" '#{pane_pid}')
+  pane_dead=$(tmux display-message -p -t "$pane_target" '#{pane_dead}' 2>/dev/null || true)
   args=
-  tool="$(tool_from_command "$cmd" || true)"
+  tool="$(pane_option "$pane_target" @codexfarm_provider)"
+  case "$tool" in
+    codex|claude|gemini) ;;
+    *) tool="" ;;
+  esac
+  if [ -z "$tool" ]; then
+    tool="$(tool_from_command "$cmd" || true)"
+  fi
   if [ -z "$tool" ]; then
     tool="$(tool_from_command "$current_cmd" || true)"
   fi
@@ -454,19 +502,23 @@ while IFS=$'\n' read -r idx; do
   provider_pid=""
   if [ -n "$tool" ]; then
     provider_pid="$(provider_pid_from_process_tree "$tool" "$pane_pid" || true)"
+    session_id="$(
+      session_id_for_pane \
+        "$tool" "$pane_target" "$pane_pid" "$provider_pid" "$pane_dead" || true
+    )"
   fi
   case "$tool" in
-    codex)
-      cmd="codex"
-      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
-      ;;
-    claude)
-      cmd="claude"
-      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
-      ;;
-    gemini)
-      cmd="gemini"
-      args="$(resume_args_for_pane "$tool" "$pane_pid" "$provider_pid")"
+    codex|claude|gemini)
+      cmd="$tool"
+      if [ -n "$session_id" ]; then
+        args="$(exact_resume_args "$tool" "$session_id")"
+      elif [ "$allow_fallback" -eq 1 ]; then
+        args="$(fallback_resume_args "$tool")"
+        echo "warning: using fallback resume for $tool window '$name'" >&2
+      else
+        unresolved_sessions=$((unresolved_sessions + 1))
+        echo "Unable to resolve exact $tool session for window '$name'." >&2
+      fi
       ;;
     *)
       cmd=$(trim_command_field "$cmd")
@@ -479,6 +531,11 @@ while IFS=$'\n' read -r idx; do
   args=${args//$'\t'/ }
   printf '%s\t%s\t%s\t%s\n' "$name" "$dir" "$cmd" "$args" >> "$tmpfile"
 done < <(tmux list-windows -t "$SESSION" -F '#{window_index}')
+
+if [ "$unresolved_sessions" -ne 0 ]; then
+  echo "Manifest was not replaced; rerun with --allow-fallback to permit latest-session resumes." >&2
+  exit 1
+fi
 
 mv "$tmpfile" "$MANIFEST_PATH"
 chmod 600 "$MANIFEST_PATH" 2>/dev/null || true

--- a/bin/codex-session-hook-install.py
+++ b/bin/codex-session-hook-install.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Install the Codex Farm session-identity hook without replacing user hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+HOOK_BASENAME = "codex-session-hook.py"
+SESSION_START_MATCHER = "startup|resume|clear|compact"
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def default_hooks_file() -> Path:
+    codex_home = os.environ.get("CODEX_HOME")
+    return Path(codex_home) / "hooks.json" if codex_home else Path.home() / ".codex" / "hooks.json"
+
+
+def load_config(path: Path, *, missing_ok: bool) -> dict[str, Any] | None:
+    if path.is_symlink():
+        raise ConfigError(f"Refusing symlinked hooks config: {path}")
+    if not path.exists():
+        return {} if missing_ok else None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"Malformed hooks config {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ConfigError(f"Malformed hooks config {path}: top level must be an object")
+    hooks = value.get("hooks")
+    if hooks is not None and not isinstance(hooks, dict):
+        raise ConfigError(f"Malformed hooks config {path}: hooks must be an object")
+    return value
+
+
+def command_targets_farm_hook(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    return any(Path(token).name == HOOK_BASENAME for token in tokens)
+
+
+def remove_farm_handlers(hooks: dict[str, Any]) -> None:
+    for event in ("SessionStart", "UserPromptSubmit"):
+        groups = hooks.get(event)
+        if groups is None:
+            continue
+        if not isinstance(groups, list):
+            raise ConfigError(f"Malformed hooks config: {event} must be an array")
+        retained_groups: list[Any] = []
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                raise ConfigError(
+                    f"Malformed hooks config: {event} matcher groups need a hooks array"
+                )
+            retained_handlers = [
+                handler
+                for handler in group["hooks"]
+                if not (
+                    isinstance(handler, dict)
+                    and handler.get("type") == "command"
+                    and command_targets_farm_hook(handler.get("command"))
+                )
+            ]
+            if retained_handlers:
+                retained_group = dict(group)
+                retained_group["hooks"] = retained_handlers
+                retained_groups.append(retained_group)
+        if retained_groups:
+            hooks[event] = retained_groups
+        else:
+            hooks.pop(event, None)
+
+
+def farm_handler(command: str) -> dict[str, Any]:
+    return {"type": "command", "command": command, "timeout": 3}
+
+
+def hook_command(hook_path: Path, python_command: str | None) -> str:
+    command = [str(hook_path)]
+    if python_command:
+        command.insert(0, python_command)
+    return shlex.join(command)
+
+
+def merge_config(
+    config: dict[str, Any],
+    hook_path: Path,
+    python_command: str | None,
+) -> dict[str, Any]:
+    updated = dict(config)
+    hooks = dict(updated.get("hooks", {}))
+    remove_farm_handlers(hooks)
+    command = hook_command(hook_path, python_command)
+    hooks.setdefault("SessionStart", []).append(
+        {
+            "matcher": SESSION_START_MATCHER,
+            "hooks": [farm_handler(command)],
+        }
+    )
+    hooks.setdefault("UserPromptSubmit", []).append({"hooks": [farm_handler(command)]})
+    updated["hooks"] = hooks
+    return updated
+
+
+def handler_is_current(handler: object, command: str) -> bool:
+    return (
+        isinstance(handler, dict)
+        and handler.get("type") == "command"
+        and handler.get("command") == command
+        and handler.get("timeout") == 3
+    )
+
+
+def config_is_current(
+    config: dict[str, Any],
+    hook_path: Path,
+    python_command: str | None,
+) -> bool:
+    hooks = config.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    command = hook_command(hook_path, python_command)
+    expected = {
+        "SessionStart": SESSION_START_MATCHER,
+        "UserPromptSubmit": None,
+    }
+    for event, matcher in expected.items():
+        groups = hooks.get(event)
+        if not isinstance(groups, list):
+            return False
+        matches = 0
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                continue
+            if matcher is not None and group.get("matcher") != matcher:
+                continue
+            if matcher is None and "matcher" in group:
+                continue
+            matches += sum(handler_is_current(handler, command) for handler in group["hooks"])
+        if matches != 1:
+            return False
+    return True
+
+
+def serialized_config(config: dict[str, Any]) -> bytes:
+    return (json.dumps(config, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def write_config(path: Path, content: bytes) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise ConfigError(f"Refusing symlinked hooks config: {path}")
+    if path.exists():
+        try:
+            if path.read_bytes() == content:
+                path.chmod(0o600)
+                return
+        except OSError as exc:
+            raise ConfigError(f"Unable to read hooks config {path}: {exc}") from exc
+
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(descriptor, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install or verify the Codex Farm session-identity hook."
+    )
+    parser.add_argument("--hooks-file", type=Path, default=default_hooks_file())
+    parser.add_argument(
+        "--hook-command",
+        type=Path,
+        default=Path(__file__).resolve().with_name(HOOK_BASENAME),
+    )
+    parser.add_argument(
+        "--python-command",
+        help="supported Python executable to place before the hook path",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit successfully only when both current handlers are installed",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        config = load_config(args.hooks_file, missing_ok=not args.check)
+        if args.check:
+            return (
+                0
+                if config is not None
+                and config_is_current(
+                    config,
+                    args.hook_command,
+                    args.python_command,
+                )
+                else 1
+            )
+        assert config is not None
+        updated = merge_config(
+            config,
+            args.hook_command,
+            args.python_command,
+        )
+        write_config(args.hooks_file, serialized_config(updated))
+    except (ConfigError, OSError) as exc:
+        print(f"codex-session-hook-install: {exc}", file=sys.stderr)
+        return 2
+    print(f"Installed Codex session hook in {args.hooks_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/codex-session-hook.py
+++ b/bin/codex-session-hook.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Record the active coding-agent session on its managed tmux pane."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+MAX_INPUT_BYTES = 1024 * 1024
+PANE_RE = re.compile(r"%[0-9]+\Z")
+UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z"
+)
+PROVIDER_EXECUTABLES = {
+    "codex": {"codex", "codex.exe", "codex.js"},
+    "claude": {"claude", "claude.exe"},
+    "gemini": {"gemini", "gemini.exe", "gemini.js"},
+}
+HOOK_EVENTS = {"SessionStart", "UserPromptSubmit"}
+
+
+def process_info(pid: int) -> tuple[int, list[str]] | None:
+    proc_dir = Path("/proc") / str(pid)
+    try:
+        stat_text = (proc_dir / "stat").read_text(encoding="utf-8")
+        after_name = stat_text.rsplit(")", 1)[1].split()
+        parent_pid = int(after_name[1])
+        cmdline = (proc_dir / "cmdline").read_bytes().split(b"\0")
+        tokens = [value.decode("utf-8", errors="replace") for value in cmdline if value]
+        comm = (proc_dir / "comm").read_text(encoding="utf-8").strip()
+        return parent_pid, [comm, *tokens]
+    except (IndexError, OSError, ValueError):
+        pass
+
+    try:
+        result = subprocess.run(
+            [
+                "ps",
+                "-p",
+                str(pid),
+                "-o",
+                "ppid=",
+                "-o",
+                "comm=",
+                "-o",
+                "args=",
+            ],
+            text=True,
+            capture_output=True,
+            timeout=1,
+            check=False,
+        )
+        fields = result.stdout.strip().split(maxsplit=2)
+        if result.returncode != 0 or len(fields) < 2:
+            return None
+        parent_pid = int(fields[0])
+        tokens = [fields[1], *fields[2].split()] if len(fields) == 3 else [fields[1]]
+        return parent_pid, tokens
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def provider_ancestor_pid(provider: str) -> int | None:
+    expected = PROVIDER_EXECUTABLES[provider]
+    pid = os.getppid()
+    visited: set[int] = set()
+    for _ in range(64):
+        if pid <= 1 or pid in visited:
+            return None
+        visited.add(pid)
+        info = process_info(pid)
+        if info is None:
+            return None
+        parent_pid, tokens = info
+        if any(Path(token).name.lower() in expected for token in tokens):
+            return pid
+        pid = parent_pid
+    return None
+
+
+def set_tmux_option(pane: str, option: str, value: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["tmux", "set-option", "-p", "-t", pane, option, value],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=1,
+            check=False,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def unset_tmux_option(pane: str, option: str) -> None:
+    try:
+        subprocess.run(
+            ["tmux", "set-option", "-p", "-u", "-t", pane, option],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def record_session() -> None:
+    if os.environ.get("CODEXFARM_MANAGED") != "1":
+        return
+
+    pane = os.environ.get("TMUX_PANE", "")
+    provider = os.environ.get("CODEXFARM_PROVIDER", "")
+    if not PANE_RE.fullmatch(pane) or provider not in PROVIDER_EXECUTABLES:
+        return
+
+    raw_payload = sys.stdin.buffer.read(MAX_INPUT_BYTES + 1)
+    if len(raw_payload) > MAX_INPUT_BYTES:
+        return
+    try:
+        payload = json.loads(raw_payload)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return
+    if not isinstance(payload, dict):
+        return
+
+    session_id = payload.get("session_id")
+    event_name = payload.get("hook_event_name")
+    if (
+        not isinstance(session_id, str)
+        or not UUID_RE.fullmatch(session_id)
+        or event_name not in HOOK_EVENTS
+    ):
+        return
+
+    provider_pid = provider_ancestor_pid(provider)
+    if provider_pid is None:
+        return
+
+    unset_tmux_option(pane, "@codexfarm_session_id")
+    metadata = [
+        ("@codexfarm_provider", provider),
+        ("@codexfarm_session_source", f"hook:{event_name}"),
+        ("@codexfarm_session_seen_at", str(int(time.time()))),
+        ("@codexfarm_session_pid", str(provider_pid)),
+    ]
+    for option, value in metadata:
+        if not set_tmux_option(pane, option, value):
+            return
+    set_tmux_option(pane, "@codexfarm_session_id", session_id)
+
+
+def main() -> int:
+    try:
+        record_session()
+    except Exception:
+        # Hooks must never interrupt the interactive provider.
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/plans/2026-07-26-session-identity-hooks-design.md
+++ b/docs/plans/2026-07-26-session-identity-hooks-design.md
@@ -1,0 +1,119 @@
+# Exact Session Identity Hooks Design
+
+## Goal
+
+Make every managed tmux pane retain the exact coding-agent conversation it is
+running, so `codex-save` and `codex-restore` cannot silently collapse several
+windows onto one provider's most recent session.
+
+The implementation covers Codex, Claude, and Gemini manifests. Codex additionally
+gets a lifecycle hook because its hook payload exposes the active conversation's
+`session_id`.
+
+## Observed Failure Modes
+
+- Older installed helpers can differ from the repository and save blank commands.
+- Native CLI window titles can change to generic values such as `node`, making
+  different panes indistinguishable by display name.
+- A missing provider session ID currently becomes `resume --last`,
+  `--continue`, or `--resume latest`; several restored windows can therefore
+  resume the same newest conversation.
+- Restore treats the first matching display name as the whole window identity,
+  so duplicate names are skipped or replaced incorrectly.
+- Process-file inspection finds exact IDs when provider internals cooperate, but
+  it is an indirect fallback rather than an authoritative session signal.
+
+## Identity Model
+
+Each pane created by `codex-add` receives invisible tmux pane options:
+
+- `@codexfarm_name`: the stable logical farm name supplied to `codex-add`.
+- `@codexfarm_provider`: `codex`, `claude`, or `gemini`.
+- `@codexfarm_session_id`: the exact provider session ID when known.
+- `@codexfarm_session_source`: where that ID came from.
+- `@codexfarm_session_seen_at`: hook observation time.
+- `@codexfarm_session_pid`: provider process that owned the observed ID.
+
+It also receives environment markers used by hooks:
+
+- `CODEXFARM_MANAGED=1`
+- `CODEXFARM_PROVIDER=<provider>`
+- `CODEXFARM_WINDOW_NAME=<stable-name>`
+
+The logical name remains independent of native title rewriting, which stays off
+by default.
+
+## Codex Hook
+
+`codex-session-hook.py` is registered for Codex `SessionStart` and
+`UserPromptSubmit` events. Codex supplies `session_id` in the hook JSON and
+passes the pane's inherited `TMUX_PANE` environment variable.
+
+The hook:
+
+1. No-ops unless it is running inside a managed farm pane.
+2. validates the pane target and UUID-shaped session ID;
+3. identifies the owning Codex process;
+4. stores metadata as tmux pane user options, writing the session ID last; and
+5. fails open without displaying IDs or disrupting Codex.
+
+Setup merges the hook into `${CODEX_HOME:-$HOME/.codex}/hooks.json`
+idempotently and preserves unrelated user hooks. Users may opt out. Codex still
+controls hook trust and can require approval through `/hooks`.
+
+Claude and Gemini continue to use provider process/session-file discovery until
+they expose an equivalent structured lifecycle signal.
+
+## Save Semantics
+
+`codex-save` prefers valid hook metadata whose recorded provider PID still owns
+the pane. If metadata is stale or absent, it falls back to the existing
+provider-specific process and file discovery.
+
+For a recognized provider, exact identity is the default safety boundary:
+
+- With an exact ID, save writes the provider's exact resume command.
+- Without an exact ID, save fails before replacing the existing manifest.
+- `--allow-fallback` explicitly restores the previous latest-session behavior.
+
+Generic shell panes remain saveable without a provider resume ID.
+
+## Restore Semantics
+
+Manifest rows are identities in their own right. Restore tracks the occurrence
+number of each logical name, so two rows named `api` create or match two separate
+windows. Re-running restore is idempotent by `(logical name, occurrence)`.
+
+Force restore removes every pre-existing occurrence for each affected logical
+name before adding all manifest rows. Exact session IDs from manifest commands
+are placed into pane metadata immediately; the Codex hook refreshes ownership
+metadata after startup.
+
+## Diagnostics and Security
+
+`codex-doctor` reports:
+
+- missing or fallback resume commands;
+- duplicate logical names in manifests; and
+- stale installed helper copies through the existing source/install comparison.
+
+Session IDs remain in owner-only manifest files and invisible pane options.
+Commands and normal hook output never print them. Hook configuration updates use
+atomic owner-only writes and reject malformed or symlinked targets.
+
+## Verification
+
+Automated coverage exercises:
+
+- hook parsing, filtering, metadata writes, and idempotent config merging;
+- hook-metadata preference and stale-metadata fallback;
+- fail-closed save plus explicit fallback opt-in;
+- two distinct sessions per provider;
+- stable names despite changing native titles;
+- duplicate-name restore and force restore;
+- doctor diagnostics and setup freshness; and
+- an isolated tmux save/restore round trip with exact session commands.
+
+Before publication, reinstall the helpers locally, inspect a real managed farm,
+run the full validation suite, push a pull request, merge it, and confirm local
+and remote `main` identify the same commit.

--- a/docs/plans/2026-07-26-session-identity-hooks.md
+++ b/docs/plans/2026-07-26-session-identity-hooks.md
@@ -1,0 +1,260 @@
+# Exact Session Identity Hooks Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Capture exact Codex conversation IDs at the tmux pane, save exact provider sessions by default, and restore every manifest row without duplicate-name collapse.
+
+**Architecture:** `codex-add` establishes stable pane identity, a small Codex lifecycle hook records authoritative session metadata, and `codex-save` validates that metadata before falling back to provider process discovery. Save fails closed for recognized agents unless fallback is explicitly requested. Restore treats repeated names by occurrence rather than as a unique key.
+
+**Tech Stack:** Bash, tmux user options and pane environments, Python 3.10 standard library, `unittest`, ShellCheck, Ruff.
+
+---
+
+### Task 1: Specify hook behavior with failing tests
+
+**Files:**
+- Create: `tests/test_session_hook.py`
+- Create: `bin/codex-session-hook.py`
+- Create: `bin/codex-session-hook-install.py`
+
+**Step 1: Write failing hook runtime tests**
+
+Cover managed-pane filtering, malformed JSON, pane and UUID validation, provider
+PID metadata, write ordering, and quiet fail-open behavior.
+
+**Step 2: Verify the tests fail for missing executables**
+
+Run: `python3 -m unittest -v tests.test_session_hook`
+
+Expected: FAIL because the hook programs do not exist.
+
+**Step 3: Implement the smallest hook runtime**
+
+Read one JSON object, validate the managed pane context, and use argument-safe
+tmux calls to set provider, source, timestamp, PID, then session ID.
+
+**Step 4: Verify runtime tests pass**
+
+Run: `python3 -m unittest -v tests.test_session_hook`
+
+Expected: PASS for runtime cases, with installer cases still pending.
+
+**Step 5: Add failing installer tests**
+
+Cover a new hooks file, preservation of unrelated handlers, replacement of a
+previous farm handler, idempotence, `--check`, malformed JSON, and symlink
+refusal.
+
+**Step 6: Verify installer tests fail for missing behavior**
+
+Run: `python3 -m unittest -v tests.test_session_hook`
+
+Expected: FAIL in installer cases.
+
+**Step 7: Implement atomic idempotent hook configuration**
+
+Merge `SessionStart` and `UserPromptSubmit` command handlers into `hooks.json`
+with mode `0600`, preserving unrelated configuration.
+
+**Step 8: Verify the hook suite passes**
+
+Run: `python3 -m unittest -v tests.test_session_hook`
+
+Expected: PASS.
+
+### Task 2: Establish stable pane identity
+
+**Files:**
+- Modify: `tests/test_add_scripts.py`
+- Modify: `bin/codex-add`
+
+**Step 1: Add a failing `codex-add` identity test**
+
+Assert that a new pane receives managed/provider/name environment variables and
+stable `@codexfarm_name` and `@codexfarm_provider` options.
+
+**Step 2: Verify the test fails**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.AddScriptTests`
+
+Expected: FAIL because `codex-add` does not yet establish pane metadata.
+
+**Step 3: Add pane environment and options**
+
+Pass environment variables to `tmux new-window`, then set the stable pane
+options after creation.
+
+**Step 4: Verify add tests pass**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.AddScriptTests`
+
+Expected: PASS.
+
+### Task 3: Make exact save identity the default
+
+**Files:**
+- Modify: `tests/test_add_scripts.py`
+- Modify: `bin/codex-save`
+
+**Step 1: Add failing save tests**
+
+Cover stable option names, fresh hook metadata, stale-PID metadata, two distinct
+sessions for each provider, default refusal when an ID is missing, explicit
+`--allow-fallback`, and preservation of an existing manifest on refusal.
+
+**Step 2: Verify the new tests fail for the intended reasons**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.SaveScriptTests`
+
+Expected: FAIL on option lookup and fail-closed expectations.
+
+**Step 3: Implement metadata resolution and safe CLI parsing**
+
+Prefer matching hook metadata, validate UUIDs, fall back to provider process
+discovery, preserve generic panes, and propagate `--allow-fallback` through
+registered-session saves.
+
+**Step 4: Implement atomic fail-closed save**
+
+Write a temporary manifest, report unresolved provider windows without IDs, and
+replace the destination only if every required exact identity was resolved.
+
+**Step 5: Verify save tests pass**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.SaveScriptTests`
+
+Expected: PASS.
+
+### Task 4: Restore duplicate logical names independently
+
+**Files:**
+- Modify: `tests/test_add_scripts.py`
+- Modify: `bin/codex-restore`
+
+**Step 1: Add failing duplicate restore tests**
+
+Cover two fresh rows with the same name, repeated restore against two existing
+occurrences, force replacement, and immediate exact-ID pane metadata.
+
+**Step 2: Verify the tests fail**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.RestoreScriptTests`
+
+Expected: FAIL because restore selects only the first matching name.
+
+**Step 3: Implement occurrence-aware matching**
+
+Resolve the Nth existing window for the Nth manifest row. For force mode, remove
+all existing occurrences for each unique manifest name before creation.
+
+**Step 4: Seed restored exact metadata**
+
+After adding a row, set its exact manifest ID and source on the corresponding
+new pane without printing it.
+
+**Step 5: Verify restore tests pass**
+
+Run: `python3 -m unittest -v tests.test_add_scripts.RestoreScriptTests`
+
+Expected: PASS.
+
+### Task 5: Install and diagnose the hook
+
+**Files:**
+- Modify: `tests/test_setup.py`
+- Modify: `tests/test_doctor.py`
+- Modify: `setup.sh`
+- Modify: `bin/codex-doctor`
+
+**Step 1: Add failing setup and doctor tests**
+
+Assert default hook installation, explicit opt-out, idempotent preservation of
+other hooks, and duplicate/fallback manifest warnings.
+
+**Step 2: Verify targeted tests fail**
+
+Run: `python3 -m unittest -v tests.test_setup tests.test_doctor`
+
+Expected: FAIL on new hook and duplicate diagnostics.
+
+**Step 3: Wire setup and diagnostics**
+
+Install the hook by default with a documented opt-out and extend manifest
+statistics without exposing session IDs.
+
+**Step 4: Verify targeted tests pass**
+
+Run: `python3 -m unittest -v tests.test_setup tests.test_doctor`
+
+Expected: PASS.
+
+### Task 6: Document and integration-test the workflow
+
+**Files:**
+- Modify: `README.md`
+- Modify: `tests/integration/session_resume_smoke.sh`
+- Modify: `validate.sh`
+
+**Step 1: Expand the isolated resume smoke test**
+
+Create two distinct sessions per supported provider and assert every saved row
+contains its own exact resume ID after restore.
+
+**Step 2: Run the integration test before changing fixtures**
+
+Run: `bash tests/integration/session_resume_smoke.sh`
+
+Expected: FAIL on the new duplicate/multi-session expectations.
+
+**Step 3: Update integration fixtures, validation, and README**
+
+Document hook trust, exact-by-default saves, fallback opt-in, stable names, and
+duplicate rows. Ensure validation uses an explicit fallback only for its generic
+mock agent if needed.
+
+**Step 4: Run focused integration checks**
+
+Run: `bash tests/integration/session_resume_smoke.sh`
+
+Expected: PASS.
+
+### Task 7: Verify, install, and publish
+
+**Files:**
+- Verify all modified files
+- Update local installed copies through `./setup.sh`
+
+**Step 1: Run static and unit verification**
+
+Run:
+- `python3 -m unittest discover -s tests -v`
+- `bash -n setup.sh bin/codex-add bin/codex-save bin/codex-restore bin/codex-doctor`
+- `shellcheck setup.sh bin/codex-add bin/codex-save bin/codex-restore bin/codex-doctor`
+- `ruff check bin tests`
+- `VALIDATE_SKIP_TMUX=1 ./validate.sh`
+
+Expected: all checks PASS.
+
+**Step 2: Run live isolated verification**
+
+Run:
+- `./validate.sh`
+- `bash tests/integration/session_resume_smoke.sh`
+
+Expected: all checks PASS without affecting the user's normal tmux server.
+
+**Step 3: Review the diff and install**
+
+Review `git diff --check`, the complete diff, and test evidence. Run
+`./setup.sh`, confirm installed helpers match the branch, and probe the live farm
+read-only for stable metadata and distinct IDs.
+
+**Step 4: Commit and push the branch**
+
+Create an intentional commit and push `fix/session-identity-hooks` to origin.
+
+**Step 5: Open, verify, and merge a pull request**
+
+Open a PR against `main`, wait for required checks, address any failures, merge
+the PR, update local `main`, and confirm local `main` and `origin/main` point to
+the merge result.

--- a/setup.sh
+++ b/setup.sh
@@ -7,18 +7,23 @@ codexfarm_setup_main() (
   set -euo pipefail
 
   local install_deep_history=0
+  local install_session_hook=1
   local setup_python=""
   while (( "$#" )); do
     case "${1:-}" in
       --with-deep-history)
         install_deep_history=1
         ;;
+      --without-session-hook)
+        install_session_hook=0
+        ;;
       -h|--help)
         cat <<'EOF'
-Usage: setup.sh [--with-deep-history]
+Usage: setup.sh [--with-deep-history] [--without-session-hook]
 
-Install Agent CLI Farm helpers. The optional flag also installs the
-checksum-pinned tmux-deep-history release used by the automatic history backend.
+Install Agent CLI Farm helpers and the Codex session-identity hook. The
+--with-deep-history flag also installs the checksum-pinned history backend.
+Use --without-session-hook to leave ~/.codex/hooks.json unchanged.
 EOF
         exit 0
         ;;
@@ -31,6 +36,9 @@ EOF
   done
   case "${CODEXFARM_WITH_DEEP_HISTORY:-}" in
     1|true|TRUE|True|yes|YES|Yes|on|ON|On) install_deep_history=1 ;;
+  esac
+  case "${CODEXFARM_INSTALL_SESSION_HOOK:-}" in
+    0|false|FALSE|False|no|NO|No|off|OFF|Off) install_session_hook=0 ;;
   esac
 
   echo "Setting up Agent CLI Farm..."
@@ -54,7 +62,7 @@ PY
   }
 
   find_python() {
-    local candidate
+    local candidate resolved resolved_dir
     for candidate in \
       "${CODEXFARM_PYTHON_BIN:-}" \
       python3 \
@@ -66,8 +74,17 @@ PY
     do
       [ -n "$candidate" ] || continue
       have_executable "$candidate" || continue
-      if python_is_supported "$candidate"; then
-        printf '%s\n' "$candidate"
+      resolved="$(command -v "$candidate" 2>/dev/null || true)"
+      [ -n "$resolved" ] || continue
+      case "$resolved" in
+        /*) ;;
+        *)
+          resolved_dir="$(cd "$(dirname "$resolved")" && pwd)" || continue
+          resolved="$resolved_dir/$(basename "$resolved")"
+          ;;
+      esac
+      if python_is_supported "$resolved"; then
+        printf '%s\n' "$resolved"
         return 0
       fi
     done
@@ -261,6 +278,21 @@ EOF
       rm -f "$HOME/bin/$legacy" && echo "Removed legacy command from $HOME/bin: $legacy"
     fi
   done
+
+  if [ "$install_session_hook" -eq 1 ]; then
+    local codex_hooks_file
+    codex_hooks_file="${CODEX_HOME:-$HOME/.codex}/hooks.json"
+    echo ""
+    echo "Installing Codex session-identity hook..."
+    "$setup_python" "$HOME/bin/codex-session-hook-install.py" \
+      --hooks-file "$codex_hooks_file" \
+      --hook-command "$HOME/bin/codex-session-hook.py" \
+      --python-command "$setup_python"
+    echo "Review and trust it with /hooks in Codex CLI."
+  else
+    echo ""
+    echo "Session hook installation skipped."
+  fi
 
   if [ "$install_deep_history" -eq 1 ]; then
     local deep_history_installer_args=()

--- a/tests/integration/session_resume_smoke.sh
+++ b/tests/integration/session_resume_smoke.sh
@@ -19,7 +19,10 @@ state_dir="$tmp_root/state"
 private_bin="$tmp_root/bin"
 project_dir="$tmp_root/project"
 tmux_tmp="$tmp_root/tmux"
-mkdir -p "$home_dir" "$config_dir" "$state_dir" "$private_bin" "$project_dir" "$tmux_tmp"
+ready_dir="$tmp_root/ready"
+mkdir -p \
+  "$home_dir" "$config_dir" "$state_dir" "$private_bin" "$project_dir" \
+  "$tmux_tmp" "$ready_dir"
 chmod 700 "$tmux_tmp"
 
 export HOME="$home_dir"
@@ -36,48 +39,87 @@ export CODEX_TIPS_PROMPT=0
 unset TMUX
 
 session="codexfarm-resume-smoke-$$"
-session_id="019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
-session_file="$HOME/.codex/sessions/2026/07/15/rollout-$session_id.jsonl"
 manifest="$config_dir/codexfarm/session-resume.tsv"
-invocation_log="$tmp_root/codex-invocations.log"
-ready_file="$tmp_root/provider-ready"
-mock_codex="$private_bin/codex"
-launcher="$private_bin/provider-launcher"
+invocation_log="$tmp_root/provider-invocations.log"
+session_map="$tmp_root/session-map.tsv"
 
-mkdir -p "$(dirname "$session_file")"
-printf '{"type":"session_meta","payload":{"id":"%s"}}\n' "$session_id" > "$session_file"
+codex_a="019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+codex_b="123e4567-e89b-42d3-a456-426614174001"
+claude_a="54f5b65c-a31c-4aa1-b91b-896b35e2a759"
+claude_b="123e4567-e89b-42d3-a456-426614174002"
+gemini_a="27bd36d0-2977-4cce-9d5d-33764d915f1d"
+gemini_b="123e4567-e89b-42d3-a456-426614174003"
 
-cat > "$mock_codex" <<'EOF'
-#!/usr/bin/env bash
+codex_a_file="$HOME/.codex/sessions/2026/07/15/rollout-$codex_a.jsonl"
+codex_b_file="$HOME/.codex/sessions/2026/07/16/rollout-$codex_b.jsonl"
+claude_a_file="$HOME/.claude/projects/-tmp-project/$claude_a.jsonl"
+claude_b_file="$HOME/.claude/projects/-tmp-project/$claude_b.jsonl"
+gemini_a_file="$HOME/.gemini/tmp/project-hash/chats/session-a.jsonl"
+gemini_b_file="$HOME/.gemini/tmp/project-hash/chats/session-b.jsonl"
+
+mkdir -p \
+  "$(dirname "$codex_a_file")" "$(dirname "$codex_b_file")" \
+  "$(dirname "$claude_a_file")" "$(dirname "$claude_b_file")" \
+  "$(dirname "$gemini_a_file")"
+printf '{"type":"session_meta","payload":{"id":"%s"}}\n' "$codex_a" > "$codex_a_file"
+printf '{"type":"session_meta","payload":{"id":"%s"}}\n' "$codex_b" > "$codex_b_file"
+printf '{"sessionId":"%s"}\n' "$claude_a" > "$claude_a_file"
+printf '{"sessionId":"%s"}\n' "$claude_b" > "$claude_b_file"
+printf '{"sessionId":"%s","projectHash":"project-hash"}\n' \
+  "$gemini_a" > "$gemini_a_file"
+printf '{"sessionId":"%s","projectHash":"project-hash"}\n' \
+  "$gemini_b" > "$gemini_b_file"
+
+{
+  printf 'codex-a\t%s\n' "$codex_a_file"
+  printf 'codex-b\t%s\n' "$codex_b_file"
+  printf 'claude-a\t%s\n' "$claude_a_file"
+  printf 'claude-b\t%s\n' "$claude_b_file"
+  printf 'gemini-a\t%s\n' "$gemini_a_file"
+  printf 'gemini-b\t%s\n' "$gemini_b_file"
+} > "$session_map"
+
+for provider in codex claude gemini; do
+  provider_bin="$private_bin/$provider"
+  cp /dev/null "$provider_bin"
+  chmod +x "$provider_bin"
+done
+
+mock_provider='#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >> "$MOCK_CODEX_INVOCATION_LOG"
-exec 9< "$MOCK_CODEX_SESSION_FILE"
-: > "$MOCK_CODEX_READY_FILE"
-trap 'exit 0' TERM INT
+provider="${0##*/}"
+printf "%s|%s\n" "$provider" "$*" >> "$MOCK_PROVIDER_INVOCATION_LOG"
+label="${1:-}"
+session_file=""
+while IFS=$'"'"'\t'"'"' read -r candidate path; do
+  if [ "$candidate" = "$label" ]; then
+    session_file="$path"
+    break
+  fi
+done < "$MOCK_PROVIDER_SESSION_MAP"
+if [ -n "$session_file" ]; then
+  exec 9< "$session_file"
+  ready_key="$label"
+else
+  last_arg=""
+  for value in "$@"; do
+    last_arg="$value"
+  done
+  ready_key="$provider-$last_arg"
+fi
+: > "$MOCK_PROVIDER_READY_DIR/$ready_key"
+trap "exit 0" TERM INT
 while :; do
   sleep 1
 done
-EOF
-chmod +x "$mock_codex"
+'
+for provider in codex claude gemini; do
+  printf '%s' "$mock_provider" > "$private_bin/$provider"
+done
 
-cat > "$launcher" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-"$MOCK_CODEX_BIN" "$@" &
-provider_pid=$!
-cleanup_provider() {
-  kill "$provider_pid" >/dev/null 2>&1 || true
-  wait "$provider_pid" >/dev/null 2>&1 || true
-}
-trap cleanup_provider EXIT HUP INT TERM
-wait "$provider_pid"
-EOF
-chmod +x "$launcher"
-
-export MOCK_CODEX_BIN="$mock_codex"
-export MOCK_CODEX_INVOCATION_LOG="$invocation_log"
-export MOCK_CODEX_READY_FILE="$ready_file"
-export MOCK_CODEX_SESSION_FILE="$session_file"
+export MOCK_PROVIDER_INVOCATION_LOG="$invocation_log"
+export MOCK_PROVIDER_SESSION_MAP="$session_map"
+export MOCK_PROVIDER_READY_DIR="$ready_dir"
 
 wait_for_file() {
   local path="$1"
@@ -87,11 +129,24 @@ wait_for_file() {
     sleep 0.05
     attempt=$((attempt + 1))
   done
-  echo "Timed out waiting for $path" >&2
+  echo "Timed out waiting for provider readiness" >&2
   return 1
 }
 
-wait_for_invocation() {
+require_manifest_row() {
+  local name="$1"
+  local command="$2"
+  local args="$3"
+  if ! awk -F '\t' -v name="$name" -v command="$command" -v args="$args" '
+    $1 == name && $3 == command && $4 == args { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$manifest"; then
+    echo "Missing exact manifest row for $name" >&2
+    return 1
+  fi
+}
+
+require_invocation() {
   local expected="$1"
   local attempt=0
   while [ "$attempt" -lt 100 ]; do
@@ -105,36 +160,84 @@ wait_for_invocation() {
   return 1
 }
 
-echo "=== Exact Session Resume Integration ==="
+start_provider() {
+  local provider="$1"
+  local label="$2"
+  CODEX_SESSION="$session" \
+    CODEX_NAME="$label" \
+    CODEX_CMD="$private_bin/$provider" \
+    "$repo_root/bin/$provider-add" -d "$project_dir" -- "$label" >/dev/null
+}
 
-CODEX_SESSION="$session" \
-  CODEX_NAME="resume-smoke" \
-  CODEX_CMD="$launcher" \
-  "$repo_root/bin/codex-add" -d "$project_dir" >/dev/null
-wait_for_file "$ready_file"
+echo "=== Exact Multi-Session Resume Integration ==="
+
+for provider in codex claude gemini; do
+  start_provider "$provider" "$provider-a"
+  start_provider "$provider" "$provider-b"
+done
+for label in codex-a codex-b claude-a claude-b gemini-a gemini-b; do
+  wait_for_file "$ready_dir/$label"
+done
 
 CODEX_SESSION="$session" "$repo_root/bin/codex-save" "$manifest" >/dev/null
-if ! awk -F '\t' -v expected="resume $session_id" '
-  $3 == "codex" && $4 == expected { found = 1 }
-  END { exit(found ? 0 : 1) }
-' "$manifest"; then
-  echo "Save did not discover the exact session through the real pane process tree" >&2
+exact_provider_rows="$(
+  awk -F '\t' '
+    $3 == "codex" && $4 ~ /^resume [0-9a-f-]+$/ { exact++ }
+    $3 == "claude" && $4 ~ /^--resume [0-9a-f-]+$/ { exact++ }
+    $3 == "gemini" && $4 ~ /^--resume [0-9a-f-]+$/ { exact++ }
+    END { print exact + 0 }
+  ' "$manifest"
+)"
+if [ "$exact_provider_rows" -ne 6 ]; then
+  echo "Expected six exact provider rows, found $exact_provider_rows" >&2
   exit 1
 fi
-if grep -Fq $'\tcodex\tresume --last' "$manifest"; then
-  echo "Save unexpectedly used the Codex fallback" >&2
+
+require_manifest_row codex-a codex "resume $codex_a"
+require_manifest_row codex-b codex "resume $codex_b"
+require_manifest_row claude-a claude "--resume $claude_a"
+require_manifest_row claude-b claude "--resume $claude_b"
+require_manifest_row gemini-a gemini "--resume $gemini_a"
+require_manifest_row gemini-b gemini "--resume $gemini_b"
+if grep -Eq $'\t(codex\tresume --last|claude\t--continue|gemini\t--resume latest)$' \
+  "$manifest"
+then
+  echo "Save unexpectedly used a provider fallback" >&2
   exit 1
 fi
-echo "[OK] save discovered the exact session from a live provider file descriptor"
+echo "[OK] save kept two exact sessions distinct for every provider"
+
+for label in codex-a codex-b claude-a claude-b gemini-a gemini-b; do
+  stable_name="$(
+    tmux show-options -p -v -t "$session:$label.0" @codexfarm_name
+  )"
+  [ "$stable_name" = "$label" ]
+done
+echo "[OK] managed panes retained stable logical names"
 
 tmux kill-session -t "$session"
 : > "$invocation_log"
-rm -f "$ready_file"
+find "$ready_dir" -type f -delete
 
 CODEX_SESSION="$session" "$repo_root/bin/codex-restore" "$manifest" >/dev/null
-wait_for_file "$ready_file"
-wait_for_invocation "resume $session_id"
-tmux list-windows -t "$session" -F '#{window_name}' | grep -Fqx "resume-smoke"
-echo "[OK] restore launched the provider with the same exact session ID"
+for provider_and_id in \
+  "codex:$codex_a" "codex:$codex_b" \
+  "claude:$claude_a" "claude:$claude_b" \
+  "gemini:$gemini_a" "gemini:$gemini_b"
+do
+  provider="${provider_and_id%%:*}"
+  session_id="${provider_and_id#*:}"
+  wait_for_file "$ready_dir/$provider-$session_id"
+  case "$provider" in
+    codex) require_invocation "codex|resume $session_id" ;;
+    claude) require_invocation "claude|--resume $session_id" ;;
+    gemini) require_invocation "gemini|--resume $session_id" ;;
+  esac
+done
 
-echo "=== Exact Session Resume Integration Complete ==="
+for label in codex-a codex-b claude-a claude-b gemini-a gemini-b; do
+  tmux list-windows -t "$session" -F '#{window_name}' | grep -Fqx "$label"
+done
+echo "[OK] restore launched all six exact provider conversations"
+
+echo "=== Exact Multi-Session Resume Integration Complete ==="

--- a/tests/test_add_scripts.py
+++ b/tests/test_add_scripts.py
@@ -146,6 +146,106 @@ esac
         ]
         self.assertEqual(title_lock_commands, [], f"Unexpected title locks: {commands}")
 
+    def test_codex_add_sets_stable_managed_pane_identity(self):
+        target_dir = self.tmpdir / "proj-stable-identity"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        env = self.env.copy()
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+        env["CODEX_NAME"] = "stable-api"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.read_tmux_commands()
+        new_window = next(command for command in commands if command[0] == "new-window")
+        self.assertIn("CODEXFARM_MANAGED=1", new_window)
+        self.assertIn("CODEXFARM_PROVIDER=codex", new_window)
+        self.assertIn("CODEXFARM_WINDOW_NAME=stable-api", new_window)
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "codexfarm:1.0",
+                "@codexfarm_name",
+                "stable-api",
+            ],
+            commands,
+        )
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "codexfarm:1.0",
+                "@codexfarm_provider",
+                "codex",
+            ],
+            commands,
+        )
+
+    def test_codex_add_does_not_label_a_custom_command_as_a_provider(self):
+        target_dir = self.tmpdir / "proj-custom-command"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        make_executable(self.tmpdir / "custom-agent", "#!/usr/bin/env bash\nexit 0\n")
+        env = self.env.copy()
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+        env["CODEX_CMD"] = "custom-agent"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.read_tmux_commands()
+        provider_options = [
+            command
+            for command in commands
+            if command and command[0] == "set-option" and "@codexfarm_provider" in command
+        ]
+        self.assertEqual(provider_options, [])
+
+    def test_codex_add_hook_environment_follows_an_explicit_provider_command(self):
+        target_dir = self.tmpdir / "proj-explicit-claude"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        env = self.env.copy()
+        env["CODEX_ANNOTATOR_AUTOSTART"] = "0"
+        env["CODEX_CMD"] = "claude"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-add", "-d", str(target_dir)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.read_tmux_commands()
+        new_window = next(command for command in commands if command[0] == "new-window")
+        self.assertIn("CODEXFARM_PROVIDER=claude", new_window)
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "codexfarm:1.0",
+                "@codexfarm_provider",
+                "claude",
+            ],
+            commands,
+        )
+
     def test_codex_add_uses_unique_logs_for_same_name_and_second(self):
         target_dir = self.tmpdir / "same-name"
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -657,6 +757,10 @@ class SaveScriptTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmpdir = Path(tempfile.mkdtemp(prefix="save-script-test-"))
         self.manifest = self.tmpdir / "manifest.tsv"
+        self.hook_session_id = "123e4567-e89b-42d3-a456-426614174000"
+        self.second_codex_session_id = "123e4567-e89b-42d3-a456-426614174001"
+        self.second_claude_session_id = "123e4567-e89b-42d3-a456-426614174002"
+        self.second_gemini_session_id = "123e4567-e89b-42d3-a456-426614174003"
 
         codex_session_path = (
             "/home/test/.codex/sessions/2026/05/11/"
@@ -666,8 +770,16 @@ class SaveScriptTests(unittest.TestCase):
         self.custom_codex_session_path = codex_session_path.replace(
             "/home/test/.codex", "/srv/custom-codex-home"
         )
+        second_codex_session_path = (
+            "/home/test/.codex/sessions/2026/05/12/"
+            "rollout-2026-05-12T04-24-28-"
+            f"{self.second_codex_session_id}.jsonl"
+        )
         claude_session_path = (
             "/home/test/.claude/projects/-tmp-project/54f5b65c-a31c-4aa1-b91b-896b35e2a759.jsonl"
+        )
+        second_claude_session_path = (
+            f"/home/test/.claude/projects/-tmp-project/{self.second_claude_session_id}.jsonl"
         )
         gemini_session_path = (
             self.tmpdir
@@ -682,6 +794,18 @@ class SaveScriptTests(unittest.TestCase):
             '{"sessionId":"27bd36d0-2977-4cce-9d5d-33764d915f1d","projectHash":"project-hash"}\n',
             encoding="utf-8",
         )
+        second_gemini_session_path = (
+            self.tmpdir
+            / ".gemini"
+            / "tmp"
+            / "project-hash"
+            / "chats"
+            / "session-2026-05-12T04-24-28second.jsonl"
+        )
+        second_gemini_session_path.write_text(
+            (f'{{"sessionId":"{self.second_gemini_session_id}","projectHash":"project-hash"}}}}\n'),
+            encoding="utf-8",
+        )
         tmux_stub = """#!/usr/bin/env bash
 set -euo pipefail
 case "$1" in
@@ -689,10 +813,41 @@ case "$1" in
     exit 0
     ;;
   list-windows)
-    printf '0\\n1\\n2\\n3\\n'
+    if [ "${MULTI_SESSION:-0}" = "1" ]; then
+      printf '0\\n1\\n2\\n3\\n4\\n5\\n6\\n'
+    else
+      printf '0\\n1\\n2\\n3\\n'
+    fi
     exit 0
     ;;
-      display-message)
+  show-options)
+    target=""
+    option=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        -p|-v) shift ;;
+        *) option="$1"; shift ;;
+      esac
+    done
+    case "$target|$option" in
+      *:1.0'|@codexfarm_name')
+        [ -n "${STABLE_CODEX_NAME:-}" ] && printf '%s\\n' "$STABLE_CODEX_NAME"
+        ;;
+      *:1.0'|@codexfarm_provider')
+        [ -n "${PANE_PROVIDER:-}" ] && printf '%s\\n' "$PANE_PROVIDER"
+        ;;
+      *:1.0'|@codexfarm_session_id')
+        [ -n "${HOOK_SESSION_ID:-}" ] && printf '%s\\n' "$HOOK_SESSION_ID"
+        ;;
+      *:1.0'|@codexfarm_session_pid')
+        [ -n "${HOOK_SESSION_PID:-}" ] && printf '%s\\n' "$HOOK_SESSION_PID"
+        ;;
+      *) exit 1 ;;
+    esac
+    exit 0
+    ;;
+  display-message)
     target=""
     format=""
     while [ "$#" -gt 0 ]; do
@@ -713,7 +868,7 @@ case "$1" in
         ;;
       *:1.0'|#{pane_current_path}') printf '/tmp/project\\n' ;;
       *:1.0'|#{pane_start_command}')
-        if [ "${SHELL_STARTED_CODEX:-0}" = "1" ]; then
+        if [ "${METADATA_ONLY:-0}" = "1" ] || [ "${SHELL_STARTED_CODEX:-0}" = "1" ]; then
           printf '\\n'
         elif [ "${WRAPPED_CODEX_START:-0}" = "1" ]; then
           printf 'tmux set-window-option -q remain-on-exit on >/dev/null 2>&1 || true; exec codex\\n'
@@ -735,6 +890,22 @@ case "$1" in
       *:3.0'|#{pane_start_command}') printf 'gemini\\n' ;;
       *:3.0'|#{pane_current_command}') printf 'node\\n' ;;
       *:3.0'|#{pane_pid}') printf '300\\n' ;;
+      *:4'|#{window_name}') printf 'codex-second\\n' ;;
+      *:4.0'|#{pane_current_path}') printf '/tmp/codex-second\\n' ;;
+      *:4.0'|#{pane_start_command}') printf 'codex\\n' ;;
+      *:4.0'|#{pane_current_command}') printf 'node\\n' ;;
+      *:4.0'|#{pane_pid}') printf '400\\n' ;;
+      *:5'|#{window_name}') printf 'claude-second\\n' ;;
+      *:5.0'|#{pane_current_path}') printf '/tmp/claude-second\\n' ;;
+      *:5.0'|#{pane_start_command}') printf 'claude\\n' ;;
+      *:5.0'|#{pane_current_command}') printf 'node\\n' ;;
+      *:5.0'|#{pane_pid}') printf '500\\n' ;;
+      *:6'|#{window_name}') printf 'gemini-second\\n' ;;
+      *:6.0'|#{pane_current_path}') printf '/tmp/gemini-second\\n' ;;
+      *:6.0'|#{pane_start_command}') printf 'gemini\\n' ;;
+      *:6.0'|#{pane_current_command}') printf 'node\\n' ;;
+      *:6.0'|#{pane_pid}') printf '600\\n' ;;
+      *'.0|#{pane_dead}') printf '0\\n' ;;
       *) exit 1 ;;
     esac
     exit 0
@@ -752,6 +923,12 @@ elif [ "$1" = "-P" ] && [ "$2" = "200" ]; then
   printf '201\\n'
 elif [ "$1" = "-P" ] && [ "$2" = "300" ]; then
   printf '301\\n'
+elif [ "$1" = "-P" ] && [ "$2" = "400" ]; then
+  printf '401\\n'
+elif [ "$1" = "-P" ] && [ "$2" = "500" ]; then
+  printf '501\\n'
+elif [ "$1" = "-P" ] && [ "$2" = "600" ]; then
+  printf '601\\n'
 fi
 """
         lsof_stub = f"""#!/usr/bin/env bash
@@ -772,6 +949,18 @@ case "$3" in
     printf 'p301\\n'
     printf 'n{gemini_session_path}\\n'
     ;;
+  401)
+    printf 'p401\\n'
+    printf 'n{second_codex_session_path}\\n'
+    ;;
+  501)
+    printf 'p501\\n'
+    printf 'n{second_claude_session_path}\\n'
+    ;;
+  601)
+    printf 'p601\\n'
+    printf 'n{second_gemini_session_path}\\n'
+    ;;
 esac
 """
         make_executable(self.tmpdir / "tmux", tmux_stub)
@@ -790,14 +979,35 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
-if [ "${SHELL_STARTED_CODEX:-0}" = "1" ]; then
-  case "$pid|$format" in
-    100'|comm=') printf 'bash\\n' ;;
-    100'|args=') printf 'bash\\n' ;;
-    101'|comm=') printf 'codex\\n' ;;
-    101'|args=') printf '/usr/local/bin/codex\\n' ;;
-  esac
+if [ "${METADATA_ONLY:-0}" = "1" ]; then
+  exit 0
 fi
+case "$pid|$format" in
+  100'|comm=') printf 'bash\\n' ;;
+  100'|args=') printf 'bash\\n' ;;
+  101'|comm=') printf 'node\\n' ;;
+  101'|args=') printf '/usr/bin/node /usr/local/bin/codex\\n' ;;
+  200'|comm=') printf 'bash\\n' ;;
+  200'|args=') printf 'bash\\n' ;;
+  201'|comm=') printf 'node\\n' ;;
+  201'|args=') printf '/usr/bin/node /usr/local/bin/claude\\n' ;;
+  300'|comm=') printf 'bash\\n' ;;
+  300'|args=') printf 'bash\\n' ;;
+  301'|comm=') printf 'node\\n' ;;
+  301'|args=') printf '/usr/bin/node /usr/local/bin/gemini\\n' ;;
+  400'|comm=') printf 'bash\\n' ;;
+  400'|args=') printf 'bash\\n' ;;
+  401'|comm=') printf 'node\\n' ;;
+  401'|args=') printf '/usr/bin/node /usr/local/bin/codex\\n' ;;
+  500'|comm=') printf 'bash\\n' ;;
+  500'|args=') printf 'bash\\n' ;;
+  501'|comm=') printf 'node\\n' ;;
+  501'|args=') printf '/usr/bin/node /usr/local/bin/claude\\n' ;;
+  600'|comm=') printf 'bash\\n' ;;
+  600'|args=') printf 'bash\\n' ;;
+  601'|comm=') printf 'node\\n' ;;
+  601'|args=') printf '/usr/bin/node /usr/local/bin/gemini\\n' ;;
+esac
 """,
         )
 
@@ -867,6 +1077,97 @@ fi
             rows,
         )
 
+    def test_codex_save_prefers_stable_name_and_provider_pane_options(self):
+        env = self.env.copy()
+        env["STACKED_WINDOW_NAME"] = "node"
+        env["STABLE_CODEX_NAME"] = "logical-codex-project"
+        env["PANE_PROVIDER"] = "codex"
+        env["METADATA_ONLY"] = "1"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        rows = self.manifest.read_text(encoding="utf-8").splitlines()
+        self.assertIn(
+            "logical-codex-project\t/tmp/project\tcodex\t"
+            "resume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
+            rows,
+        )
+        self.assertFalse(any(row.startswith("node\t") for row in rows))
+
+    def test_codex_save_prefers_fresh_hook_session_metadata(self):
+        env = self.env.copy()
+        env["HOOK_SESSION_ID"] = self.hook_session_id
+        env["HOOK_SESSION_PID"] = "101"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        rows = self.manifest.read_text(encoding="utf-8").splitlines()
+        self.assertIn(
+            f"proj\t/tmp/project\tcodex\tresume {self.hook_session_id}",
+            rows,
+        )
+        self.assertNotIn(
+            "proj\t/tmp/project\tcodex\tresume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
+            rows,
+        )
+
+    def test_codex_save_ignores_hook_metadata_owned_by_a_stale_pid(self):
+        env = self.env.copy()
+        env["HOOK_SESSION_ID"] = self.hook_session_id
+        env["HOOK_SESSION_PID"] = "999"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        rows = self.manifest.read_text(encoding="utf-8").splitlines()
+        self.assertIn(
+            "proj\t/tmp/project\tcodex\tresume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
+            rows,
+        )
+        self.assertNotIn(self.hook_session_id, "\n".join(rows))
+
+    def test_codex_save_records_two_distinct_sessions_for_each_provider(self):
+        env = self.env.copy()
+        env["MULTI_SESSION"] = "1"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        rows = self.manifest.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(rows), 7)
+        expected_args = {
+            "proj": "resume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
+            "codex-second": f"resume {self.second_codex_session_id}",
+            "claude-proj": "--resume 54f5b65c-a31c-4aa1-b91b-896b35e2a759",
+            "claude-second": f"--resume {self.second_claude_session_id}",
+            "gemini-proj": "--resume 27bd36d0-2977-4cce-9d5d-33764d915f1d",
+            "gemini-second": f"--resume {self.second_gemini_session_id}",
+        }
+        actual_args = {
+            fields[0]: fields[3] for row in rows[1:] if len(fields := row.split("\t")) == 4
+        }
+        self.assertEqual(actual_args, expected_args)
+        for first, second in (
+            ("proj", "codex-second"),
+            ("claude-proj", "claude-second"),
+            ("gemini-proj", "gemini-second"),
+        ):
+            self.assertNotEqual(actual_args[first], actual_args[second])
+
     def test_codex_save_rejects_extra_manifest_arguments(self):
         result = subprocess.run(
             [REPO_ROOT / "bin" / "codex-save", str(self.manifest), str(self.tmpdir / "other.tsv")],
@@ -919,13 +1220,37 @@ fi
         env["NO_CODEX_SESSION"] = "1"
 
         subprocess.run(
-            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            [
+                REPO_ROOT / "bin" / "codex-save",
+                "--allow-fallback",
+                str(self.manifest),
+            ],
             check=True,
             env=env,
         )
 
         rows = self.manifest.read_text(encoding="utf-8").splitlines()
         self.assertIn("proj\t/tmp/project\tcodex\tresume --last", rows)
+
+    def test_codex_save_refuses_fallback_and_preserves_existing_manifest(self):
+        original = b"existing manifest must survive\n"
+        self.manifest.write_bytes(original)
+        env = self.env.copy()
+        env["NO_CODEX_SESSION"] = "1"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-save", str(self.manifest)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(self.manifest.read_bytes(), original)
+        self.assertIn("exact codex session", result.stderr.lower())
+        self.assertIn("--allow-fallback", result.stderr)
+        self.assertNotIn(self.hook_session_id, result.stderr)
 
     def test_codex_save_all_registered_writes_each_registered_manifest(self):
         registry = Path(self.env["XDG_CONFIG_HOME"]) / "codexfarm" / "farms.tsv"
@@ -947,6 +1272,35 @@ fi
         self.assertIn(
             "proj\t/tmp/project\tcodex\tresume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4",
             rows,
+        )
+
+    def test_codex_save_all_registered_propagates_allow_fallback(self):
+        registry = Path(self.env["XDG_CONFIG_HOME"]) / "codexfarm" / "farms.tsv"
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        work_manifest = self.tmpdir / "work-fallback.tsv"
+        registry.write_text(
+            f"session\tmanifest\nwork\t{work_manifest}\n",
+            encoding="utf-8",
+        )
+        env = self.env.copy()
+        env["NO_CODEX_SESSION"] = "1"
+
+        result = subprocess.run(
+            [
+                REPO_ROOT / "bin" / "codex-save",
+                "--all-registered",
+                "--allow-fallback",
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "proj\t/tmp/project\tcodex\tresume --last",
+            work_manifest.read_text(encoding="utf-8").splitlines(),
         )
 
 
@@ -982,6 +1336,28 @@ case "$1" in
     if [ -n "${TMUX_WINDOWS_OUTPUT:-}" ]; then
       printf '%s\n' "${TMUX_WINDOWS_OUTPUT}"
     fi
+    if [ -f "${TMUX_STATE_FILE}" ]; then
+      cat "${TMUX_STATE_FILE}"
+    fi
+    exit 0
+    ;;
+  show-options)
+    target=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ "$target" = "${TMUX_STABLE_TARGET:-}" ] && [ -n "${TMUX_STABLE_NAME:-}" ]; then
+      printf '%s\n' "$TMUX_STABLE_NAME"
+    fi
+    exit 0
+    ;;
+  kill-window)
+    if [ "${3:-}" = "${TMUX_KILL_FAIL_TARGET:-}" ]; then
+      exit 1
+    fi
     exit 0
     ;;
   *)
@@ -992,6 +1368,14 @@ esac
         codex_add_stub = """#!/usr/bin/env bash
 set -euo pipefail
 echo "$CODEX_NAME|$CODEX_CMD|$CODEX_ARGS|$*" >> "${CODEX_ADD_LOG}"
+count=0
+if [ -f "${TMUX_STATE_FILE}" ]; then
+  while IFS= read -r _line; do
+    count=$((count + 1))
+  done < "${TMUX_STATE_FILE}"
+fi
+count=$((count + 1))
+printf '@new%s\\t%s\\n' "$count" "$CODEX_NAME" >> "${TMUX_STATE_FILE}"
 exit 0
 """
         make_executable(self.tmpdir / "tmux", tmux_stub)
@@ -1006,6 +1390,7 @@ exit 0
         self.env = os.environ.copy()
         self.env["PATH"] = f"{self.tmpdir}:{self.env.get('PATH', '')}"
         self.env["TMUX_LOG"] = str(self.tmux_log)
+        self.env["TMUX_STATE_FILE"] = str(self.tmpdir / "tmux-state.tsv")
         self.env["CODEX_ADD_LOG"] = str(self.codex_add_log)
         self.env["CODEX_AUTOSERVICE_CHOICE"] = "no"
         self.env.pop("TMUX", None)
@@ -1017,7 +1402,41 @@ exit 0
         lines = self.tmux_log.read_text(encoding="utf-8").splitlines()
         return [line.split() for line in lines]
 
+    def write_duplicate_manifest(self) -> tuple[str, str]:
+        first_id = "019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+        second_id = "123e4567-e89b-42d3-a456-426614174001"
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\n"
+            f"dup\t{self.project_dir}\tcodex\tresume {first_id}\n"
+            f"dup\t{self.project_dir}\tcodex\tresume {second_id}\n",
+            encoding="utf-8",
+        )
+        return first_id, second_id
+
     def test_codex_restore_launches_saved_codex_resume_command(self):
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=self.env,
+        )
+
+        add_calls = (
+            self.codex_add_log.read_text(encoding="utf-8").splitlines()
+            if self.codex_add_log.exists()
+            else []
+        )
+        self.assertEqual(
+            add_calls,
+            [f"proj|codex|resume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4|-d {self.project_dir}"],
+        )
+        self.assertFalse(
+            any(cmd and cmd[0] == "send-keys" for cmd in self.read_tmux_commands()),
+            "restore should launch the resume command instead of typing it into a running CLI",
+        )
+
+    def test_codex_restore_creates_every_fresh_duplicate_name_row(self):
+        first_id, second_id = self.write_duplicate_manifest()
+
         subprocess.run(
             [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
             check=True,
@@ -1027,12 +1446,148 @@ exit 0
         add_calls = self.codex_add_log.read_text(encoding="utf-8").splitlines()
         self.assertEqual(
             add_calls,
-            [f"proj|codex|resume 019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4|-d {self.project_dir}"],
+            [
+                f"dup|codex|resume {first_id}|-d {self.project_dir}",
+                f"dup|codex|resume {second_id}|-d {self.project_dir}",
+            ],
         )
-        self.assertFalse(
-            any(cmd and cmd[0] == "send-keys" for cmd in self.read_tmux_commands()),
-            "restore should launch the resume command instead of typing it into a running CLI",
+
+    def test_codex_restore_adds_only_missing_duplicate_occurrence(self):
+        _first_id, second_id = self.write_duplicate_manifest()
+        env = self.env.copy()
+        env["TMUX_WINDOWS_OUTPUT"] = "@9\tdup"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
         )
+
+        add_calls = (
+            self.codex_add_log.read_text(encoding="utf-8").splitlines()
+            if self.codex_add_log.exists()
+            else []
+        )
+        self.assertEqual(
+            add_calls,
+            [f"dup|codex|resume {second_id}|-d {self.project_dir}"],
+        )
+
+    def test_codex_restore_is_idempotent_with_two_existing_duplicates(self):
+        self.write_duplicate_manifest()
+        env = self.env.copy()
+        env["TMUX_WINDOWS_OUTPUT"] = "@9\tdup\n@10\t*READY* dup"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        self.assertFalse(self.codex_add_log.exists())
+
+    def test_codex_restore_force_replaces_all_duplicate_occurrences_once(self):
+        self.write_duplicate_manifest()
+        env = self.env.copy()
+        env["TMUX_WINDOWS_OUTPUT"] = "@9\tdup\n@10\t*READY* dup"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", "--force", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        commands = self.read_tmux_commands()
+        killed = [command for command in commands if command[0] == "kill-window"]
+        self.assertEqual(
+            killed,
+            [["kill-window", "-t", "@9"], ["kill-window", "-t", "@10"]],
+        )
+        self.assertEqual(
+            len(self.codex_add_log.read_text(encoding="utf-8").splitlines()),
+            2,
+        )
+
+    def test_codex_restore_force_stops_if_an_existing_window_cannot_be_removed(self):
+        self.write_duplicate_manifest()
+        env = self.env.copy()
+        env["TMUX_WINDOWS_OUTPUT"] = "@9\tdup"
+        env["TMUX_KILL_FAIL_TARGET"] = "@9"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", "--force", str(self.manifest)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(self.codex_add_log.exists())
+        self.assertIn("Unable to remove existing window", result.stderr)
+
+    def test_codex_restore_seeds_exact_session_metadata_without_printing_id(self):
+        session_id = "019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.read_tmux_commands()
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "@new1.0",
+                "@codexfarm_provider",
+                "codex",
+            ],
+            commands,
+        )
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "@new1.0",
+                "@codexfarm_session_source",
+                "restore",
+            ],
+            commands,
+        )
+        self.assertIn(
+            [
+                "set-option",
+                "-p",
+                "-t",
+                "@new1.0",
+                "@codexfarm_session_id",
+                session_id,
+            ],
+            commands,
+        )
+        self.assertNotIn(session_id, result.stdout)
+        self.assertNotIn(session_id, result.stderr)
+
+    def test_codex_restore_matches_stable_pane_name_when_native_title_changes(self):
+        env = self.env.copy()
+        env["TMUX_WINDOWS_OUTPUT"] = "@9\tnode"
+        env["TMUX_STABLE_TARGET"] = "@9.0"
+        env["TMUX_STABLE_NAME"] = "proj"
+
+        subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            check=True,
+            env=env,
+        )
+
+        self.assertFalse(self.codex_add_log.exists())
 
     def test_codex_restore_requests_tab_delimited_window_fields(self):
         env = self.env.copy()
@@ -1088,6 +1643,36 @@ exit 0
 
         add_calls = self.codex_add_log.read_text(encoding="utf-8").splitlines()
         self.assertEqual(add_calls, [f"proj|gemini|--resume latest|-d {self.project_dir}"])
+
+    def test_codex_restore_keeps_wrapper_provider_for_a_custom_command(self):
+        custom_agent = self.tmpdir / "custom-agent"
+        checking_add = self.tmpdir / "checking-add"
+        make_executable(custom_agent, "#!/usr/bin/env bash\nexit 0\n")
+        make_executable(
+            checking_add,
+            """#!/usr/bin/env bash
+set -euo pipefail
+[ "${CODEX_TOOL_NAME}" = codex ]
+[ "${CODEX_CMD}" = "${EXPECTED_CUSTOM_COMMAND}" ]
+""",
+        )
+        self.manifest.write_text(
+            f"name\tdir\tcmd\targs\ncustom\t{self.project_dir}\t{custom_agent}\t--flag\n",
+            encoding="utf-8",
+        )
+        env = self.env.copy()
+        env["CODEX_ADD_BIN"] = str(checking_add)
+        env["EXPECTED_CUSTOM_COMMAND"] = str(custom_agent)
+
+        result = subprocess.run(
+            [REPO_ROOT / "bin" / "codex-restore", str(self.manifest)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_codex_restore_skips_existing_annotated_window_name(self):
         env = self.env.copy()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -148,6 +148,37 @@ esac
         self.assertIn("exact provider sessions: 0", result.stdout)
         self.assertIn("provider command(s) with invalid resume arguments", result.stdout)
 
+    def test_non_uuid_resume_value_is_not_counted_as_an_exact_session(self) -> None:
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\nproject\t/tmp/project\tcodex\tresume not-a-uuid\n",
+            encoding="utf-8",
+        )
+        self.manifest.chmod(0o600)
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("exact provider sessions: 0", result.stdout)
+        self.assertIn("provider command(s) with invalid resume arguments", result.stdout)
+
+    def test_duplicate_logical_names_are_reported_without_printing_ids(self) -> None:
+        second_id = "123e4567-e89b-42d3-a456-426614174001"
+        self.manifest.write_text(
+            "name\tdir\tcmd\targs\n"
+            f"project\t/tmp/project\tcodex\tresume {SESSION_ID}\n"
+            f"project\t/tmp/other\tcodex\tresume {second_id}\n",
+            encoding="utf-8",
+        )
+        self.manifest.chmod(0o600)
+
+        result = self.run_doctor(self.manifest)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("duplicate names: 1", result.stdout)
+        self.assertIn("duplicate logical name occurrence", result.stdout)
+        self.assertNotIn(SESSION_ID, result.stdout)
+        self.assertNotIn(second_id, result.stdout)
+
     def test_rejects_duplicate_session_arguments(self) -> None:
         result = subprocess.run(
             [DOCTOR_BIN, "--session", "one", "--session", "two", self.manifest],

--- a/tests/test_farm_reboot.py
+++ b/tests/test_farm_reboot.py
@@ -158,6 +158,21 @@ esac
         self.assertFalse(any("kill-session" in line for line in lines))
         self.assertFalse(any(line.startswith("restore ") for line in lines))
 
+    def test_allow_fallback_is_passed_only_to_the_save_step(self) -> None:
+        self.env["TMUX_EXISTING_SESSIONS"] = "codexfarm"
+
+        result = self.run_reboot("--allow-fallback", "--detach")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "save tool=codex session=codexfarm args=--allow-fallback",
+            self.log_lines(),
+        )
+        self.assertIn(
+            "restore tool=codex session=codexfarm args=",
+            self.log_lines(),
+        )
+
     def test_restore_failure_reports_recovery_command(self) -> None:
         self.env["TMUX_EXISTING_SESSIONS"] = "codexfarm board"
         self.env["RESTORE_EXIT"] = "8"
@@ -235,6 +250,7 @@ esac
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Usage: gemini-farm-reboot", result.stdout)
+        self.assertIn("--allow-fallback", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_hook.py
+++ b/tests/test_session_hook.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK = REPO_ROOT / "bin" / "codex-session-hook.py"
+INSTALLER = REPO_ROOT / "bin" / "codex-session-hook-install.py"
+SESSION_ID = "019e1659-3a2f-7a40-95cf-5ac9dd7fe5d4"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+class SessionHookRuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="session-hook-test-")
+        self.root = Path(self.temp_dir.name)
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        self.tmux_log = self.root / "tmux.log"
+
+        make_executable(
+            self.fake_bin / "tmux",
+            """#!/usr/bin/env bash
+{
+  printf '%q ' "$@"
+  printf '\\n'
+} >> "$TMUX_LOG"
+""",
+        )
+        make_executable(
+            self.fake_bin / "codex",
+            """#!/usr/bin/env bash
+"$@"
+""",
+        )
+
+        self.env = os.environ.copy()
+        self.env["PATH"] = f"{self.fake_bin}:{self.env.get('PATH', '')}"
+        self.env["TMUX_LOG"] = str(self.tmux_log)
+        self.env["TMUX_PANE"] = "%17"
+        self.env["CODEXFARM_MANAGED"] = "1"
+        self.env["CODEXFARM_PROVIDER"] = "codex"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_hook(
+        self,
+        payload: str,
+        *,
+        env: dict[str, str] | None = None,
+        through_provider: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [HOOK]
+        if through_provider:
+            command = [self.fake_bin / "codex", HOOK]
+        return subprocess.run(
+            command,
+            input=payload,
+            env=env or self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def tmux_commands(self) -> list[list[str]]:
+        if not self.tmux_log.exists():
+            return []
+        return [
+            shlex.split(line) for line in self.tmux_log.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def test_records_valid_session_metadata_and_writes_session_id_last(self) -> None:
+        result = self.run_hook(
+            f'{{"hook_event_name":"SessionStart","session_id":"{SESSION_ID}","cwd":"/tmp/project"}}'
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        commands = self.tmux_commands()
+        self.assertEqual(
+            [commands[0][5], *[command[4] for command in commands[1:]]],
+            [
+                "@codexfarm_session_id",
+                "@codexfarm_provider",
+                "@codexfarm_session_source",
+                "@codexfarm_session_seen_at",
+                "@codexfarm_session_pid",
+                "@codexfarm_session_id",
+            ],
+        )
+        self.assertEqual(
+            commands[0],
+            ["set-option", "-p", "-u", "-t", "%17", "@codexfarm_session_id"],
+        )
+        self.assertTrue(
+            all(command[:4] == ["set-option", "-p", "-t", "%17"] for command in commands[1:])
+        )
+        self.assertEqual(commands[1][5], "codex")
+        self.assertEqual(commands[2][5], "hook:SessionStart")
+        self.assertGreater(int(commands[3][5]), 0)
+        self.assertGreater(int(commands[4][5]), 0)
+        self.assertEqual(commands[5][5], SESSION_ID)
+
+    def test_ignores_unmanaged_panes(self) -> None:
+        env = self.env.copy()
+        env.pop("CODEXFARM_MANAGED")
+
+        result = self.run_hook(
+            f'{{"hook_event_name":"SessionStart","session_id":"{SESSION_ID}"}}',
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(self.tmux_commands(), [])
+
+    def test_ignores_malformed_input_invalid_pane_and_invalid_uuid(self) -> None:
+        cases = [
+            ("not-json", self.env),
+            (
+                f'{{"hook_event_name":"SessionStart","session_id":"{SESSION_ID}"}}',
+                {**self.env, "TMUX_PANE": "codexfarm:1"},
+            ),
+            (
+                '{"hook_event_name":"SessionStart","session_id":"latest"}',
+                self.env,
+            ),
+        ]
+
+        for payload, env in cases:
+            with self.subTest(payload=payload, pane=env["TMUX_PANE"]):
+                result = self.run_hook(payload, env=env)
+                self.assertEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(result.stderr, "")
+
+        self.assertEqual(self.tmux_commands(), [])
+
+    def test_does_not_record_metadata_without_a_provider_ancestor(self) -> None:
+        env = {**self.env, "CODEXFARM_PROVIDER": "claude"}
+        result = self.run_hook(
+            f'{{"hook_event_name":"UserPromptSubmit","session_id":"{SESSION_ID}"}}',
+            env=env,
+            through_provider=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(self.tmux_commands(), [])
+
+
+class SessionHookInstallerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="session-hook-install-test-")
+        self.root = Path(self.temp_dir.name)
+        self.hooks_file = self.root / ".codex" / "hooks.json"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_installer(
+        self,
+        *arguments: str,
+        hooks_file: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                INSTALLER,
+                "--hooks-file",
+                hooks_file or self.hooks_file,
+                "--hook-command",
+                HOOK,
+                *arguments,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def read_config(self) -> dict[str, object]:
+        return json.loads(self.hooks_file.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def farm_handlers(config: dict[str, object], event: str) -> list[dict[str, object]]:
+        hooks = config["hooks"]
+        assert isinstance(hooks, dict)
+        groups = hooks[event]
+        assert isinstance(groups, list)
+        return [
+            handler
+            for group in groups
+            for handler in group["hooks"]
+            if Path(shlex.split(handler["command"])[-1]).name == "codex-session-hook.py"
+        ]
+
+    def test_installs_both_events_owner_only_and_is_idempotent(self) -> None:
+        first = self.run_installer()
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        config = self.read_config()
+        self.assertEqual(stat.S_IMODE(self.hooks_file.stat().st_mode), 0o600)
+        self.assertEqual(len(self.farm_handlers(config, "SessionStart")), 1)
+        self.assertEqual(len(self.farm_handlers(config, "UserPromptSubmit")), 1)
+        session_groups = config["hooks"]["SessionStart"]
+        self.assertEqual(session_groups[0]["matcher"], "startup|resume|clear|compact")
+        first_bytes = self.hooks_file.read_bytes()
+
+        second = self.run_installer()
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(self.hooks_file.read_bytes(), first_bytes)
+        config = self.read_config()
+        self.assertEqual(len(self.farm_handlers(config, "SessionStart")), 1)
+        self.assertEqual(len(self.farm_handlers(config, "UserPromptSubmit")), 1)
+
+    def test_preserves_unrelated_hooks_and_replaces_old_farm_handlers(self) -> None:
+        self.hooks_file.parent.mkdir(parents=True)
+        existing = {
+            "description": "keep me",
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "startup",
+                        "hooks": [
+                            {"type": "command", "command": "echo unrelated"},
+                            {
+                                "type": "command",
+                                "command": "python3 /old/codex-session-hook.py",
+                                "timeout": 9,
+                            },
+                        ],
+                    }
+                ],
+                "UserPromptSubmit": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "/old/codex-session-hook.py",
+                            }
+                        ]
+                    }
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "echo post"}],
+                    }
+                ],
+            },
+        }
+        self.hooks_file.write_text(json.dumps(existing), encoding="utf-8")
+
+        result = self.run_installer()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        config = self.read_config()
+        self.assertEqual(config["description"], "keep me")
+        serialized = json.dumps(config)
+        self.assertIn("echo unrelated", serialized)
+        self.assertIn("echo post", serialized)
+        self.assertNotIn("/old/codex-session-hook.py", serialized)
+        self.assertEqual(len(self.farm_handlers(config, "SessionStart")), 1)
+        self.assertEqual(len(self.farm_handlers(config, "UserPromptSubmit")), 1)
+
+    def test_can_pin_the_supported_python_command_for_hook_runtime(self) -> None:
+        result = self.run_installer("--python-command", "python3.12")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        config = self.read_config()
+        for event in ("SessionStart", "UserPromptSubmit"):
+            handlers = self.farm_handlers(config, event)
+            self.assertEqual(
+                handlers[0]["command"],
+                shlex.join(["python3.12", str(HOOK)]),
+            )
+
+    def test_check_reports_whether_both_current_handlers_are_installed(self) -> None:
+        missing = self.run_installer("--check")
+        self.assertEqual(missing.returncode, 1)
+
+        installed = self.run_installer()
+        self.assertEqual(installed.returncode, 0, installed.stderr)
+        current = self.run_installer("--check")
+        self.assertEqual(current.returncode, 0, current.stderr)
+
+        config = self.read_config()
+        del config["hooks"]["UserPromptSubmit"]
+        self.hooks_file.write_text(json.dumps(config), encoding="utf-8")
+        incomplete = self.run_installer("--check")
+        self.assertEqual(incomplete.returncode, 1)
+
+    def test_rejects_malformed_or_symlinked_config_without_overwriting(self) -> None:
+        self.hooks_file.parent.mkdir(parents=True)
+        malformed = "{not json"
+        self.hooks_file.write_text(malformed, encoding="utf-8")
+
+        malformed_result = self.run_installer()
+
+        self.assertEqual(malformed_result.returncode, 2)
+        self.assertEqual(self.hooks_file.read_text(encoding="utf-8"), malformed)
+        self.assertIn("malformed", malformed_result.stderr.lower())
+
+        self.hooks_file.unlink()
+        target = self.root / "target.json"
+        target.write_text('{"hooks": {}}', encoding="utf-8")
+        self.hooks_file.symlink_to(target)
+
+        symlink_result = self.run_installer()
+
+        self.assertEqual(symlink_result.returncode, 2)
+        self.assertEqual(target.read_text(encoding="utf-8"), '{"hooks": {}}')
+        self.assertIn("symlink", symlink_result.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,6 @@
+import json
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -80,6 +82,65 @@ class SetupScriptTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--with-deep-history", result.stdout)
+        self.assertIn("--without-session-hook", result.stdout)
+
+    def test_installs_session_hook_and_preserves_unrelated_user_hooks(self) -> None:
+        (self.bin_dir / "python3").unlink()
+        (self.bin_dir / "python3").symlink_to(sys.executable)
+        make_executable(self.bin_dir / "tmux", "#!/usr/bin/env bash\nexit 0\n")
+        make_executable(self.bin_dir / "multitail", "#!/usr/bin/env bash\nexit 0\n")
+        hooks_file = Path(self.env["HOME"]) / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        hooks_file.write_text(
+            json.dumps(
+                {
+                    "description": "preserve",
+                    "hooks": {
+                        "PostToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [{"type": "command", "command": "echo existing"}],
+                            }
+                        ]
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        first = self.run_setup()
+        second = self.run_setup()
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        config = json.loads(hooks_file.read_text(encoding="utf-8"))
+        self.assertEqual(config["description"], "preserve")
+        self.assertIn("echo existing", json.dumps(config))
+        expected_hook = Path(self.env["HOME"]) / "bin" / "codex-session-hook.py"
+        commands = [
+            handler["command"]
+            for event in ("SessionStart", "UserPromptSubmit")
+            for group in config["hooks"][event]
+            for handler in group["hooks"]
+            if Path(shlex.split(handler["command"])[-1]).name == "codex-session-hook.py"
+        ]
+        expected_command = shlex.join([str(self.bin_dir / "python3"), str(expected_hook)])
+        self.assertEqual(commands, [expected_command, expected_command])
+        self.assertEqual(stat.S_IMODE(hooks_file.stat().st_mode), 0o600)
+        self.assertIn("Review and trust it with /hooks", first.stdout)
+
+    def test_without_session_hook_skips_user_config_change(self) -> None:
+        (self.bin_dir / "python3").unlink()
+        (self.bin_dir / "python3").symlink_to(sys.executable)
+        make_executable(self.bin_dir / "tmux", "#!/usr/bin/env bash\nexit 0\n")
+        make_executable(self.bin_dir / "multitail", "#!/usr/bin/env bash\nexit 0\n")
+        hooks_file = Path(self.env["HOME"]) / ".codex" / "hooks.json"
+
+        result = self.run_setup("--without-session-hook")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(hooks_file.exists())
+        self.assertIn("Session hook installation skipped", result.stdout)
 
     def test_sourced_setup_forwards_deep_history_flag(self) -> None:
         (self.bin_dir / "python3").unlink()
@@ -264,7 +325,10 @@ exit 98
         result = self.run_setup()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Using Python interpreter: python3.12", result.stdout)
+        self.assertIn(
+            f"Using Python interpreter: {self.bin_dir / 'python3.12'}",
+            result.stdout,
+        )
 
     def test_installed_python_wrappers_fall_back_to_versioned_python(self) -> None:
         make_fake_python(self.bin_dir / "python3", 3, 9)

--- a/validate.sh
+++ b/validate.sh
@@ -111,6 +111,10 @@ check_static_behavior() {
     require_output "codex-board help" "Usage:" "$repo_root/bin/codex-board" --help
     require_output "codex-farm-reboot help" "Usage:" "$repo_root/bin/codex-farm-reboot" --help
     require_output "codex-doctor help" "Usage:" "$repo_root/bin/codex-doctor" --help
+    require_output "codex-save exact-session help" "allow-fallback" \
+        "$repo_root/bin/codex-save" --help
+    require_output "session hook installer help" "session-identity hook" \
+        python3 "$repo_root/bin/codex-session-hook-install.py" --help
     require_output "codex-status help" "Usage:" "$repo_root/bin/codex-status" --help
     require_output "codex-looper help" "Tiny coding-agent looper" "$repo_root/bin/codex-looper" --help
     require_output "codex-watch help" "Usage:" "$repo_root/bin/codex-watch" --help
@@ -143,7 +147,7 @@ check_static_behavior() {
 }
 
 run_live_tmux_checks() {
-    local mock_agent project manifest mode
+    local mock_agent project manifest mode stable_name provider_option
     if ! command -v tmux >/dev/null 2>&1; then
         echo "tmux not found; live validation cannot run" >&2
         exit 127
@@ -172,8 +176,16 @@ EOF
 
     tmux has-session -t "$main_session"
     tmux list-windows -t "$main_session" -F '#{window_name}' | grep -q "validate-test"
+    stable_name="$(tmux show-options -p -v -t "$main_session:validate-test.0" \
+      @codexfarm_name)"
+    [ "$stable_name" = "validate-test" ]
+    provider_option="$(
+      tmux show-options -p -v -t "$main_session:validate-test.0" \
+        @codexfarm_provider 2>/dev/null || true
+    )"
+    [ -z "$provider_option" ]
     CODEX_SESSION="$main_session" "$repo_root/bin/codex-status" sessions >/dev/null
-    echo "[OK] farm session, window, and status listing"
+    echo "[OK] farm session, stable pane identity, and status listing"
 
     CODEX_SESSION="$main_session" "$repo_root/bin/codex-board" create >/dev/null
     CODEX_SESSION="$main_session" "$repo_root/bin/codex-board" link >/dev/null


### PR DESCRIPTION
## What changed

- add a Codex lifecycle hook that records the active conversation ID on its managed tmux pane
- preserve stable logical pane names independently of native CLI window titles
- make provider saves require exact UUIDs by default, with an explicit `--allow-fallback` escape hatch
- restore duplicate logical window names by occurrence instead of collapsing them onto the first match
- seed exact restore metadata and abort force restore when an existing window cannot be removed
- install and merge the user hook configuration safely, preserving unrelated hooks and pinning the supported Python interpreter
- extend doctor diagnostics, setup/docs, and Codex/Claude/Gemini integration coverage

## Why

Session discovery previously depended entirely on provider process files and silently emitted latest/continue fallbacks when an exact ID was missing. Native title changes could also make several windows share a generic name such as `node`, while restore treated that name as a unique key. Together those behaviors could restore multiple windows into the same newest conversation.

The new path keeps an authoritative Codex ID at the tmux layer, validates PID ownership before using cached metadata, retains process-file discovery for all providers, and refuses to replace a manifest when exact identity is unresolved unless fallback was explicitly requested.

## User impact

- existing safe exact-session manifests continue to restore
- unresolved provider panes now stop save without overwriting the previous manifest
- `codex-save --allow-fallback` and `codex-farm-reboot --allow-fallback` retain the legacy behavior when intentionally requested
- setup adds two owner-only lifecycle handlers; Codex may require approval through `/hooks`
- existing panes created before installation gain the new metadata after recreation; process-file discovery still applies meanwhile

## Validation

- `CODEX_ANNOTATOR_AUTOSTART=0 python3 -m unittest discover -s tests -v` — 309 tests passed
- `ruff format --check .` and `ruff check .` — clean with Ruff 0.12.2
- repository-wide ShellCheck at warning severity — clean
- `tests/integration/session_resume_smoke.sh` — two exact sessions each for Codex, Claude, and Gemini saved/restored distinctly
- `./validate.sh` — isolated live tmux lifecycle completed
- `git diff --check` — clean
